### PR TITLE
Added required attributes, added required field styling

### DIFF
--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -9,7 +9,7 @@
 		createAttributeSyncEffect
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { requiredLabel, filterAttributes } from '$lib/utils/helpers';
+	import { filterAttributes } from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 
 	const { item, printing = false } = $props<{
@@ -18,7 +18,7 @@
 	}>();
 
 	let checked = $state(item?.value ?? item.attributes?.defaultChecked ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required ?? false);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let readonly = $state(item.is_read_only ?? false);
 	let touched = $state(false);
 
@@ -106,6 +106,7 @@
 			class={item.class}
 			bind:checked
 			disabled={readonly}
+			required={item.is_required}
 			{onchange}
 			{onblur}
 		>

--- a/src/lib/components/formfields/DatePicker.svelte
+++ b/src/lib/components/formfields/DatePicker.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/utils/valueSync';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import './fields.css';
-	import { requiredLabel, filterAttributes } from '$lib/utils/helpers';
+	import { filterAttributes } from '$lib/utils/helpers';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -19,7 +19,7 @@
 
 	let value = $state(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? '');
 	let readOnly = $state(item.is_read_only ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let helperText = item.help_text ?? item.description ?? '';
 	let touched = $state(false);
 

--- a/src/lib/components/formfields/NumberInput.svelte
+++ b/src/lib/components/formfields/NumberInput.svelte
@@ -9,7 +9,7 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { requiredLabel, filterAttributes } from '$lib/utils/helpers';
+	import { filterAttributes } from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 
 	let { item, printing = false } = $props<{ item: Item; printing?: boolean }>();
@@ -17,7 +17,7 @@
 	let value = $state(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? 0);
 	let error = $state(item.attributes?.error ?? '');
 	let readonly = $state(item.is_read_only ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required ?? false);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let helperText = item.help_text ?? item.description ?? '';
 	let touched = $state(false);
 
@@ -94,6 +94,7 @@
 			{readonly}
 			invalid={!!anyError}
 			invalidText={anyError}
+			required={item.is_required}
 			{oninput}
 			{onblur}
 		>

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/utils/valueSync';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import './fields.css';
-	import { requiredLabel, filterAttributes } from '$lib/utils/helpers';
+	import { filterAttributes } from '$lib/utils/helpers';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -22,7 +22,7 @@
 	);
 	let error = $state(item.attributes?.error ?? '');
 	let readonly = $state(item.is_read_only ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required ?? false);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let helperText = item.help_text ?? item.description ?? '';
 	let options = item.options ?? [];
 	let touched = $state(false);
@@ -110,6 +110,7 @@
 			bind:selected
 			role="radiogroup"
 			data-selected={selected}
+			required={item.is_required}
 			{onchange}
 		>
 			<span slot="legendText">{@html labelText}</span>

--- a/src/lib/components/formfields/Select.svelte
+++ b/src/lib/components/formfields/Select.svelte
@@ -9,7 +9,7 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { requiredLabel, filterAttributes } from '$lib/utils/helpers';
+	import {  filterAttributes } from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 
 	const { item, printing = false } = $props<{
@@ -22,7 +22,7 @@
 	);
 	let error = $state(item.attributes?.error ?? '');
 	let readOnly = $state(item.is_read_only ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required ?? false);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let helperText = item.help_text ?? item.description ?? '';
 	let options = item.options ?? [];
 	let touched = $state(false);
@@ -105,6 +105,7 @@
 			disabled={readOnly}
 			invalid={!!anyError}
 			invalidText={anyError}
+			required={item.is_required}
 			{onchange}
 			{onblur}
 		>

--- a/src/lib/components/formfields/TextArea.svelte
+++ b/src/lib/components/formfields/TextArea.svelte
@@ -9,7 +9,7 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { requiredLabel, filterAttributes } from '$lib/utils/helpers';
+	import { filterAttributes } from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 
 	const { item, printing = false } = $props<{
@@ -20,7 +20,7 @@
 	let value = $state(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? '');
 	let error = $state(item.attributes?.error ?? '');
 	let readOnly = $state(item.is_read_only ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required ?? false);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let placeholder = item.attributes?.placeholder ?? '';
 	let helperText = item.help_text ?? item.description ?? '';
 	let maxlength = item.attributes?.maxCount ?? undefined;
@@ -100,6 +100,7 @@
 			readonly={readOnly}
 			invalid={!!anyError}
 			invalidText={anyError}
+			required={item.is_required}
 			{maxlength}
 			{oninput}
 			{onblur}

--- a/src/lib/components/formfields/TextInput.svelte
+++ b/src/lib/components/formfields/TextInput.svelte
@@ -21,7 +21,7 @@
 	let value = $state(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? '');
 	let error = $state(item.attributes?.error ?? '');
 	let readOnly = $state(item.is_read_only ?? false);
-	let labelText = requiredLabel(item.attributes?.labelText ?? '', item.is_required ?? false);
+	let labelText = $state(item.attributes?.labelText ?? '');
 	let placeholder = item.attributes?.placeholder ?? '';
 	let helperText = item.help_text ?? item.description ?? '';
 
@@ -114,6 +114,7 @@
 				use:maska={mask}
 				readonly={readOnly}
 				aria-invalid={!!anyError}
+				required={item.is_required}
 				{...maxCount ? { maxlength: maxCount } : {}}
 				{oninput}
 				{onblur}
@@ -137,6 +138,7 @@
 				invalid={!!anyError}
 				invalidText={anyError}
 				{hideLabel}
+				required={item.is_required}
 				{...maxCount ? { maxlength: maxCount } : {}}
 				{oninput}
 				{onblur}

--- a/src/lib/web.css
+++ b/src/lib/web.css
@@ -139,3 +139,9 @@
   gap: 0;
 }
 
+/* Add red asterisk to "required" labels */
+.bx--label--required::after {
+  content: '*';
+  color: #da1e28;  /* Carbon red60 */
+  margin-left: 2px;
+}


### PR DESCRIPTION
I have added the required attribute to textinputs using the "is_required" prop. I have also removed the use of the requiredLabel function and instead use CSS to append the red asterisk to labels for required elements.

## What changes did you make?

I changed TextInput.svelte and web.css to remove the use of the requiredLabel function and instead rely on css to add a red asterisk to required field labels.  I also added the insertion of a required attribute using the "is_required" prop boolean.

## Why did you make these changes?

Required attributes are a necessary accessibility feature for screen-readers and a useful affordance for Javascript. Moreover, the requiredLabel function, as defined, was buggy because it returns HTML which is then stripped by the carbon component to leave the label text empty - this solves both problems.

## What alternatives did you consider?

Haruspexy, but that hardly seems relevant.

### Checklist

- [? ] **I have assigned at least one reviewer**
- [ ?] **My code meets the style guide**
- [ 💩 ] **My code has adequate test coverage (if applicable)**
