### PR TITLE
Move data binding logic to kiln-api on /view and /preview pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.idea

--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -4,7 +4,6 @@
 	import { Button, Form, Modal, Loading } from 'carbon-components-svelte';
 	import FormRenderer from './components/FormRenderer.svelte';
 	import ScriptStyleInjection from './components/ScriptStyleInjection.svelte';
-	import { bindDataToForm } from './utils/databinder';
 	import { FORM_MODE } from './constants/formMode';
 	import {
 		saveDataToICMApi,
@@ -64,18 +63,12 @@
 
 	let mergedFormData = $derived.by(() => {
 		if (!formData) return null;
+
 		if (mode === 'view') {
 			setReadOnlyFields(formData);
 		}
-		if (saveData && formData) {
-			const { mappedFormDef } = bindDataToForm({
-				data: saveData.data,
-				form_definition: formData
-			});
-			return mappedFormDef;
-		} else {
-			return formData;
-		}
+		
+		return formData;
 	});
 
 	let ministryLogoPath = $derived.by(() => {

--- a/src/lib/types/load.ts
+++ b/src/lib/types/load.ts
@@ -29,6 +29,7 @@ export interface UseFormLoaderOptions {
   expectSaveData?: boolean;
   parseErrorBody?: boolean;
   includeOriginalServer?: boolean;
+  transformParams?: (params: Record<string, string>) => Record<string, any>;
 }
 
 export interface UseFormLoaderReturn {

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -33,6 +33,7 @@ export const API = {
   unlockICMData: getApiUrl("/clearICMLockedFlag", import.meta.env.VITE_COMM_API_UNLOCK_ICM_FORM_URL),
   submitForButtonAction: getApiUrl("/submitForPortalAction", import.meta.env.VITE_COMM_API_SUBMIT_TO_ACTION_ENDPOINT_URL),  
   loadBoundForm: getApiUrl("/loadBoundForm", import.meta.env.VITE_COMM_API_LOAD_BOUND_FORM_ENDPOINT_URL),
+  bindPreviewForm: getApiUrl("/bindPreviewForm", import.meta.env.VITE_COMM_API_BIND_PREVIEW_FORM_ENDPOINT_URL),
   getFormById: `${getKlammApiBaseUrl()}/api/form-versions/`,
   getFormKlammURL: `${getKlammApiBaseUrl()}/forms/form-versions/`,
 } ;

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -31,7 +31,8 @@ export const API = {
   saveICMData: getApiUrl("/saveICMData", import.meta.env.VITE_COMM_API_SAVEDATA_ICM_ENDPOINT_URL),
   pdfTemplate:  getApiUrl("/pdfRender", import.meta.env.VITE_COMM_API_PDFTEMPLATE_ENDPOINT_URL),
   unlockICMData: getApiUrl("/clearICMLockedFlag", import.meta.env.VITE_COMM_API_UNLOCK_ICM_FORM_URL),
-  submitForButtonAction: getApiUrl("/submitForPortalAction", import.meta.env.VITE_COMM_API_SUBMIT_TO_ACTION_ENDPOINT_URL),
+  submitForButtonAction: getApiUrl("/submitForPortalAction", import.meta.env.VITE_COMM_API_SUBMIT_TO_ACTION_ENDPOINT_URL),  
+  loadBoundForm: getApiUrl("/loadBoundForm", import.meta.env.VITE_COMM_API_LOAD_BOUND_FORM_ENDPOINT_URL),
   getFormById: `${getKlammApiBaseUrl()}/api/form-versions/`,
   getFormKlammURL: `${getKlammApiBaseUrl()}/forms/form-versions/`,
 } ;

--- a/src/lib/utils/useFormLoader.ts
+++ b/src/lib/utils/useFormLoader.ts
@@ -19,7 +19,8 @@ export function useFormLoader({
 	apiEndpoint,
 	expectSaveData = false,
 	parseErrorBody = true,
-	includeOriginalServer = true
+	includeOriginalServer = true,
+	transformParams
 }: UseFormLoaderOptions): UseFormLoaderReturn {
 	const isLoading = writable(true);
 	const error = writable<string | null>(null);
@@ -55,7 +56,9 @@ export function useFormLoader({
 				const payload = expectSaveData ? (result?.save_data ?? result) : result;
 				formData.set(payload?.form_definition ?? payload ?? {});
 				saveData.set(result?.data ? { data: result.data } : {});
-			} else {
+			} else {				
+				const finalParams = transformParams ? transformParams(params) : params;
+
 				// Delegate fetch and error handling to loadFormData
 				let raw: any = undefined;
 				await loadFormData(
@@ -70,7 +73,7 @@ export function useFormLoader({
 					},
 					{
 						endpoint: apiEndpoint,
-						params,
+						params: finalParams,
 						setLoading: (v) => isLoading.set(v),
 						includeAuth: true,
 						includeOriginalServer,

--- a/src/routes/edit/+page.svelte
+++ b/src/routes/edit/+page.svelte
@@ -9,7 +9,12 @@
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { isLoading, error, formData, saveData } = useFormLoader({
-		apiEndpoint: isPortalIntegrated ? API.loadPortalForm : API.loadICMData
+		apiEndpoint: API.loadBoundForm,
+		expectSaveData: false,
+		transformParams: (params) => ({
+			...params,
+			isPortalIntegrated
+		})
 	});
 </script>
 

--- a/src/routes/generate/+page.svelte
+++ b/src/routes/generate/+page.svelte
@@ -6,7 +6,12 @@
 	import { FORM_MODE, FORM_DELIVERY_MODE } from '$lib/constants/formMode';
 
 	const { isLoading, error, formData, saveData } = useFormLoader({
-		apiEndpoint: API.loadICMData
+		apiEndpoint: API.loadBoundForm,
+		expectSaveData: false,
+		transformParams: (params) => ({
+			...params,
+			isPortalIntegrated: false
+		})
 	});
 </script>
 

--- a/src/routes/view/+page.svelte
+++ b/src/routes/view/+page.svelte
@@ -9,7 +9,12 @@
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { isLoading, error, formData, saveData } = useFormLoader({
-		apiEndpoint: isPortalIntegrated ? API.loadPortalForm : API.loadICMData
+		apiEndpoint: API.loadBoundForm,
+		expectSaveData: false,
+		transformParams: (params) => ({
+			...params,
+			isPortalIntegrated
+		})
 	});
 </script>
 


### PR DESCRIPTION
## What changes did you make?

Change to move the data bind logic to kiln-api, as kiln-v2 should only be the form renderer client.

## Why did you make these changes?

This change is needed for better separation of concerns between kiln-v2 (frontend) and kiln-api (backend).

## What alternatives did you consider?

There are no alternative solutions for this change.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [X] **My code has adequate test coverage (if applicable)**
