### PR TITLE
Add Authorization headers to API calls for kiln-api compatibility

### DIFF
--- a/src/lib/utils/auth-headers.ts
+++ b/src/lib/utils/auth-headers.ts
@@ -1,0 +1,63 @@
+import { getKeycloak, getAuthHeader } from './keycloak';
+
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  };
+
+  try {
+    // Try to get fresh token from keycloak
+    const authHeader = await getAuthHeader();
+    if (authHeader?.Authorization) {
+      headers.Authorization = authHeader.Authorization;
+    }
+  } catch (error) {
+    // Fallback to cookie-based auth
+    if (typeof window !== 'undefined') {
+      const username = getCookie('username');
+      // Note: For cookie-based auth, username goes in body, not headers
+    }
+  }
+
+  // Add Original-Server header if available
+  if (typeof window !== 'undefined') {
+    const originalServer = getCookie('originalServer');
+    if (originalServer) {
+      headers['X-Original-Server'] = originalServer;
+    }
+  }
+
+  return headers;
+}
+
+export function getAuthBody(): Record<string, any> {
+  const body: Record<string, any> = {};
+
+  if (typeof window !== 'undefined') {
+    const keycloak = getKeycloak();
+
+    if (keycloak?.token) {
+      body.token = keycloak.token;
+    } else {
+      // Fallback to cookie-based username
+      const username = getCookie('username');
+      if (username && username.length > 0) {
+        body.username = username.trim();
+      }
+    }
+  }
+
+  return body;
+}
+
+function getCookie(name: string): string | null {
+  if (typeof window === 'undefined') return null;
+
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    const cookieValue = parts.pop()?.split(';').shift();
+    return cookieValue ? decodeURIComponent(cookieValue) : null;
+  }
+  return null;
+}

--- a/src/lib/utils/form.ts
+++ b/src/lib/utils/form.ts
@@ -283,9 +283,12 @@ export async function unlockICMFinalFlags(): Promise<string> {
       }
     }
 
+    const { getAuthHeaders } = await import('./auth-headers');
+    const headers = await getAuthHeaders();
+
     const response = await fetch(unlockICMFinalEndpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(body)
     });
 
@@ -310,10 +313,13 @@ export async function unlockICMFinalFlags(): Promise<string> {
 export async function generatePDF(formData: FormDefinition, pdfId: string){
   const payload: Record<string, any> = {}
   		try {
+			const { getAuthHeaders } = await import('./auth-headers');
+			const headers = await getAuthHeaders();
+
 			const payload = {}
 			const response = await fetch(`/api/pdf-template/${pdfId}`, {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers,
 				body: JSON.stringify(payload)
 			});
 

--- a/src/lib/utils/load.ts
+++ b/src/lib/utils/load.ts
@@ -50,6 +50,14 @@ try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
+
+    if (includeAuth) {
+      const token = keycloak?.token ?? (getCookie("token") as string | null) ?? null;
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+    }
+
     if (includeOriginalServer) {
       const originalServer = getCookie("originalServer");
       if (originalServer) headers["X-Original-Server"] = originalServer as string;


### PR DESCRIPTION
## What changes did you make?

- Created auth-headers.ts utility to centralize authentication header management
- Enhanced load.ts to include Authorization headers in all API requests to kiln-api
- Updated form.ts functions (unlockICMFinalFlags, generatePDF) to use consistent auth headers
- Maintained backwards compatibility by keeping token/username in the request body alongside new Authorization headers

## Why did you make these changes?

These changes establish proper authentication flow between kiln-v2 and the new kiln-api backend. Previously, authentication was only passed in the request body (old pattern), but modern APIs expect Authorization headers.

The kiln-api needs to receive authentication tokens to forward them to ICM backend services. Without these changes, kiln-api wouldn't receive the necessary authentication to make ICM API calls on behalf of users.

## What alternatives did you consider?

Considered integration with API Program Services (APS), but the current approach is simpler and easier to maintain.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [X] **My code has adequate test coverage (if applicable)**
