### PR TITLE
Ado 3174 checkbox print styles

### DIFF
--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -42,7 +42,6 @@
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
 	let touched = $state(false);
 
-	let touched = $state(false);
 	let extAttrs = $state<Record<string, any>>({});
 
 	let filteredAttributes = $derived.by(() => {

--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -19,16 +19,16 @@
 	}>();
 
 	let checked = $state(item?.value ?? item.attributes?.defaultChecked ?? false);
-	let labelText = $state(getFieldLabel(item));
-	let readonly = $state(item.is_read_only ?? false);
-	let helperText = item.help_text ?? '';
-	let hideLabel = item.attributes?.hideLabel ?? false;
-	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
-	let touched = $state(false);
+	let labelText = $derived(getFieldLabel(item));
+	let readonly = $derived(item.is_read_only ?? false);
+	let helperText = $derived(item.help_text ?? '');
+	let hideLabel = $derived(item.attributes?.hideLabel ?? false);
+	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
 
+	let touched = $state(false);
 	let extAttrs = $state<Record<string, any>>({});
 
-	const filteredAttributes = $derived.by(() => {
+	let filteredAttributes = $derived.by(() => {
 		const attrs = { ...(item.attributes ?? {}) } as Record<string, any>;
 		delete attrs.checked;
 		delete attrs.defaultChecked;
@@ -36,10 +36,10 @@
 		return attrs;
 	});
 
-	const rules = $derived.by(() =>
+	let rules = $derived.by(() =>
 		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'boolean' })
 	);
-	const anyError = $derived.by(() => {
+	let anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (item.attributes?.error) return item.attributes.error;
 		if (readonly) return '';

--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -12,6 +12,8 @@
 	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+	import CheckboxIcon from 'carbon-icons-svelte/lib/Checkbox.svelte';
+	import CheckboxFilledIcon from 'carbon-icons-svelte/lib/CheckboxCheckedFilled.svelte';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -87,17 +89,32 @@
 		publishToGlobalFormState({ item, value: checked });
 	});
 
-	const a11y = buildFieldAria({
-		uuid: item.uuid,
-		labelText,
-		helperText,
-		isRequired: item.is_required,
-		readOnly: readonly
-	});
+	let a11y = $derived(
+		buildFieldAria({
+			uuid: item.uuid,
+			labelText,
+			helperText,
+			isRequired: item.is_required,
+			readOnly: readonly
+		})
+	);
 </script>
 
 <div class="field-container checkbox-field">
-	<PrintRow {item} {printing} {labelText} value={checked ? '☑' : '☐'} />
+	<PrintRow item={{ ...item, is_required: false }} {printing} labelText="">
+		{#snippet value()}
+			<div class="checkbox-print-label">
+				<span class="checkbox-icon">
+					{#if checked}
+						<CheckboxFilledIcon aria-label="Checked" />
+					{:else}
+						<CheckboxIcon aria-label="Unchecked" />
+					{/if}
+				</span>
+				<span class:required={item.is_required}>{@html labelText}</span>
+			</div>
+		{/snippet}
+	</PrintRow>
 
 	<div
 		class="web-input"
@@ -162,12 +179,21 @@
 	.required::after {
 		content: ' *';
 		color: var(--cds-support-error);
-	}	
+	}
 	.bx--form-requirement.checkbox-error {
 		display: block;
 		overflow: visible;
 		max-height: 12.5rem;
 		font-weight: 400;
 		color: var(--cds-text-error, #da1e28);
+	}
+	.checkbox-print-label {
+		display: flex;
+		gap: 0.375rem;
+		align-items: center;
+	}
+	.checkbox-icon {
+		display: flex;
+		flex-shrink: 0;
 	}
 </style>

--- a/src/lib/components/formfields/CheckboxGroup.svelte
+++ b/src/lib/components/formfields/CheckboxGroup.svelte
@@ -6,6 +6,8 @@
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
 	import './fields.css';
+	import CheckboxIcon from "carbon-icons-svelte/lib/Checkbox.svelte";
+	import CheckboxFilledIcon from "carbon-icons-svelte/lib/CheckboxCheckedFilled.svelte";
 
 	const { item, printing = false } = $props<{ item: Item; printing?: boolean }>();
 
@@ -53,19 +55,11 @@
 		);
 	});
 
-	const printValue = $derived(
-		options
-			.map((opt) => {
-				const prefix = selected.includes(opt.value) ? '☑ ' : '☐ ';
-				return prefix + (opt.label || opt.value);
-			})
-			.join('\n')
-	);
-
 	const filteredAttributes = $derived(() => {
 		const attrs = { ...(item.attributes ?? {}) };
 		delete attrs.defaultSelected;
 		delete attrs.disabled;
+		delete attrs.options;
 		return attrs;
 	});
 
@@ -109,7 +103,22 @@
 </script>
 
 <div class="field-container checkbox-group-field">
-	<PrintRow {item} {printing} {labelText} value={printValue} />
+	<PrintRow {item} {printing} {labelText}>
+		{#snippet value()}
+			{#each options as opt (opt.value)}
+				<div class="checkbox-print-option">
+					<span class="checkbox-icon">
+						{#if selected.includes(opt.value)}
+							<CheckboxFilledIcon aria-label="Checked" />
+						{:else}
+							<CheckboxIcon aria-label="Unchecked" />
+						{/if}
+					</span>
+					<span>{@html opt.label || opt.value}</span>
+				</div>
+			{/each}
+		{/snippet}
+	</PrintRow>
 
 	<div
 		class="web-input checkbox-group-wrapper"
@@ -194,5 +203,14 @@
 		max-height: 12.5rem;
 		font-weight: 400;
 		color: var(--cds-text-error, #da1e28);
+	}
+	.checkbox-print-option {
+		display: flex;
+		gap: 0.375rem;
+		align-items: center;
+	}
+	.checkbox-icon {
+		display: flex;
+		flex-shrink: 0;
 	}
 </style>

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -12,6 +12,8 @@
 	import './fields.css';
 	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
 	import PrintRow from './common/PrintRow.svelte';
+	import RadioIcon from 'carbon-icons-svelte/lib/RadioButton.svelte';
+	import RadioFilledIcon from 'carbon-icons-svelte/lib/RadioButtonChecked.svelte';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -83,22 +85,30 @@
 
 	const a11y = $derived(
 		buildFieldAria({
-		uuid: item.uuid,
-		labelText,
-		helperText,
-		isRequired: item.is_required,
-		readOnly: readonly
+			uuid: item.uuid,
+			labelText,
+			helperText,
+			isRequired: item.is_required,
+			readOnly: readonly
 		})
 	);
 </script>
 
 {#snippet value()}
-	{#each options as opt (opt.id)}
-		<div class="bx--radio-button-wrapper" style="display: flex; align-items: center; gap: 10px;">
-			<div>{selected === opt.value ? '◉' : '○'}</div>
-			<div>{opt.label}</div>
-		</div>
-	{/each}
+	<div class="radio-print-options" class:horizontal={item.attributes?.orientation === 'horizontal'}>
+		{#each options as opt (opt.id)}
+			<div class="radio-print-option">
+				<span class="radio-icon">
+					{#if selected.includes(opt.value)}
+						<RadioFilledIcon aria-label="Selected" />
+					{:else}
+						<RadioIcon aria-label="Not selected" />
+					{/if}
+				</span>
+				<span>{@html opt.label || opt.value}</span>
+			</div>
+		{/each}
+	</div>
 {/snippet}
 
 <div class="field-container radio-button-field">
@@ -164,5 +174,19 @@
 		max-height: 12.5rem;
 		font-weight: 400;
 		color: var(--cds-text-error, #da1e28);
+	}
+	.radio-print-options.horizontal {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1rem;
+	}
+	.radio-print-option {
+		display: flex;
+		gap: 0.375rem;
+		align-items: center;
+	}
+	.radio-icon {
+		display: flex;
+		flex-shrink: 0;
 	}
 </style>

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -22,12 +22,12 @@
 		item?.value ?? item.attributes?.selected ?? item.attributes?.defaultSelected ?? ''
 	);
 	let error = $state(item.attributes?.error ?? '');
-	let readonly = $state(item.is_read_only ?? false);
-	let labelText = $state(getFieldLabel(item));
-	let hideLabel = item.attributes?.hideLabel ?? false;
-	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
-	let helperText = item.help_text ?? '';
-	let options = item.options ?? [];
+	let readonly = $derived(item.is_read_only ?? false);
+	let labelText = $derived(getFieldLabel(item));
+	let hideLabel = $derived(item.attributes?.hideLabel ?? false);
+	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
+	let helperText = $derived(item.help_text ?? '');
+	let options = $derived(item.options ?? []);
 	let touched = $state(false);
 
 	let extAttrs = $state<Record<string, any>>({});
@@ -81,13 +81,15 @@
 		publishToGlobalFormState({ item, value: selected });
 	});
 
-	const a11y = buildFieldAria({
+	const a11y = $derived(
+		buildFieldAria({
 		uuid: item.uuid,
 		labelText,
 		helperText,
 		isRequired: item.is_required,
 		readOnly: readonly
-	});
+		})
+	);
 </script>
 
 {#snippet value()}

--- a/src/lib/components/formfields/fields.css
+++ b/src/lib/components/formfields/fields.css
@@ -36,7 +36,7 @@
  	overflow-wrap: anywhere;
 	width: 70%;
 	min-height: 24px;
-	padding: 2px 10px;
+	padding: 10px;
 	font-size: 13px;
 	font-weight: 300;
 }


### PR DESCRIPTION
## What changes did you make?

- Moved checkbox field's label to the value column in print rows
- updated checkbox and radio fields to use carbon icons in print view
- touched up styling of checkbox/radio print views to make spacing consistent
- enabled horizontal support for radio print view

## Why did you make these changes?

The unicode characters used for printed checkboxes/radios were hard to read, inconsistently sized, and difficult to style.

For single checkboxes, having the label in the print-label column left it cramped in most use-cases, and the checkbox being along in the print-value column looked weird. For now I elected to leave the print-label column there, but empty, to maintain consistent alignment with other rows.

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
