### PR TITLE
Handle readonly/required based on portal state

### DIFF
--- a/src/lib/components/formfields/Button.svelte
+++ b/src/lib/components/formfields/Button.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
 	import { Button } from 'carbon-components-svelte';
 	import type { Item } from '$lib/types/form';
-	import { filterAttributes, getFieldLabel } from '$lib/utils/helpers';
+	import { filterAttributes, getFieldLabel, computeIsReadOnly } from '$lib/utils/helpers';
 	import { syncExternalAttributes } from '$lib/utils/valueSync';
 	import { buildFieldAria } from '$lib/utils/helpers';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	let { item, printing = false } = $props<{ item: Item; printing?: boolean; [key: string]: any }>();
 	let labelText = $derived(getFieldLabel(item));
 	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
-	let readonly = $state(item.is_read_only ?? false);
+	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 
 	let extAttrs = $state<Record<string, any>>({});
 	let ariaLabel = $derived(labelText || item.name || 'button');
@@ -32,7 +34,7 @@
 </script>
 
 <div
-	class="field-container button-field no-print" 
+	class="field-container button-field no-print"
 	class:visible={!printing && item.visible_web !== false && !readonly}
 	class:moustache={enableVarSub}
 >

--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -9,9 +9,17 @@
 		createAttributeSyncEffect
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -20,7 +28,13 @@
 
 	let checked = $state(item?.value ?? item.attributes?.defaultChecked ?? false);
 	let labelText = $state(getFieldLabel(item));
-	let readonly = $state(item.is_read_only ?? false);
+
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state (bindings, UI)
+	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let helperText = item.help_text ?? '';
 	let hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
@@ -37,7 +51,7 @@
 	});
 
 	const rules = $derived.by(() =>
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'boolean' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'boolean' })
 	);
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
@@ -87,13 +101,15 @@
 		publishToGlobalFormState({ item, value: checked });
 	});
 
-	const a11y = buildFieldAria({
-		uuid: item.uuid,
-		labelText,
-		helperText,
-		isRequired: item.is_required,
-		readOnly: readonly
-	});
+	const a11y = $derived.by(() =>
+		buildFieldAria({
+			uuid: item.uuid,
+			labelText,
+			helperText,
+			isRequired,
+			readOnly: isReadOnly
+		})
+	);
 </script>
 
 <div class="field-container checkbox-field">
@@ -121,7 +137,7 @@
 			<span
 				slot="labelChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 		</Checkbox>
@@ -162,7 +178,7 @@
 	.required::after {
 		content: ' *';
 		color: var(--cds-support-error);
-	}	
+	}
 	.bx--form-requirement.checkbox-error {
 		display: block;
 		overflow: visible;

--- a/src/lib/components/formfields/CheckboxGroup.svelte
+++ b/src/lib/components/formfields/CheckboxGroup.svelte
@@ -2,10 +2,18 @@
 	import { Checkbox, CheckboxGroup } from 'carbon-components-svelte';
 	import type { FormOption, Item } from '$lib/types/form';
 	import { publishToGlobalFormState, syncExternalAttributes } from '$lib/utils/valueSync';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
 	import './fields.css';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{ item: Item; printing?: boolean }>();
 
@@ -21,7 +29,12 @@
 	let error = $state(item.attributes?.error ?? '');
 	let extAttrs = $state<Record<string, any>>({});
 
-	let readOnly = $derived(item.is_read_only ?? false);
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state
+	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	// Derived
 	const options = $derived((item.options ?? []) as FormOption[]);
 	const labelText = $derived(getFieldLabel(item));
@@ -29,18 +42,18 @@
 	const helperText = $derived(item.help_text ?? '');
 	const enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
 
-	const a11y = $derived(
+	const a11y = $derived.by(() =>
 		buildFieldAria({
 			uuid: item.uuid,
 			labelText,
 			helperText,
-			isRequired: item.is_required,
-			readOnly
+			isRequired,
+			readOnly: isReadOnly
 		})
 	);
 
 	const rules = $derived(
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'string' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 
 	const anyError = $derived.by(() => {
@@ -130,7 +143,7 @@
 			<span
 				slot="legendChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 

--- a/src/lib/components/formfields/Container.svelte
+++ b/src/lib/components/formfields/Container.svelte
@@ -3,6 +3,7 @@
 	import { Add, TrashCan } from 'carbon-icons-svelte';
 	import FieldRenderer from '../FieldRenderer.svelte';
 	import type { Item } from '$lib/types/form';
+	import { computeIsReadOnly } from '$lib/utils/helpers';
 
 	let {
 		item,
@@ -13,6 +14,11 @@
 		mode: string;
 		printing?: boolean;
 	} = $props();
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
+
+	// Compute effective read-only from enum value
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 
 	// Fall back for crypto.randomUUID (not available in insecure contexts like host.docker.internal)
 	function generateUUID(): string {
@@ -276,7 +282,7 @@
 							>{repeaterItemLabel}
 							{repeaterItemLabel ? idx + 1 : ' '}</span
 						>
-						{#if groupCount > 1 && !item.is_read_only}
+						{#if groupCount > 1 && !isReadOnly}
 							<Button
 								kind="ghost"
 								onclick={() => removeGroup(idx)}
@@ -320,7 +326,7 @@
 				</div>
 			</div>
 		{/each}
-		{#if !printing && !item.is_read_only && isRepeatable}
+		{#if !printing && !isReadOnly && isRepeatable}
 			<div class="custom-buttons-only">
 				<Button kind="ghost" onclick={addGroup} icon={Add} class="no-print">Add another</Button>
 			</div>

--- a/src/lib/components/formfields/CurrencyInput.svelte
+++ b/src/lib/components/formfields/CurrencyInput.svelte
@@ -9,11 +9,19 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { preprocessDecimalInput, unmaskNumberString } from '$lib/utils/mask';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
 	import { MaskInput } from 'maska';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	let {
 		item,
@@ -28,7 +36,12 @@
 	);
 	let unmaskedValue: string = $derived(unmaskNumberString(value));
 
-	let readOnly = $derived(item.is_read_only === true || item.is_read_only === 'true' || false);
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state
+	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $derived(getFieldLabel(item));
 	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
 	let placeholder = $derived(item.attributes?.placeholder ?? '');
@@ -42,7 +55,7 @@
 	let ref = $state<HTMLInputElement | null>(null);
 
 	let rules = $derived.by(() => ({
-		...rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'number' }),
+		...rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'number' }),
 		isInteger: false
 	}));
 	let anyError = $derived.by(() => {
@@ -98,13 +111,13 @@
 		publishToGlobalFormState({ item, value: unmaskedValue });
 	});
 
-	const a11y = $derived(
+	const a11y = $derived.by(() =>
 		buildFieldAria({
 			uuid: item.uuid,
 			labelText,
 			helperText,
-			isRequired: item.is_required,
-			readOnly: readOnly
+			isRequired,
+			readOnly: isReadOnly
 		})
 	);
 
@@ -156,7 +169,7 @@
 			<span
 				slot="labelChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 		</TextInput>

--- a/src/lib/components/formfields/DatePicker.svelte
+++ b/src/lib/components/formfields/DatePicker.svelte
@@ -4,16 +4,29 @@
 	import { createAttributeSyncEffect, publishToGlobalFormState } from '$lib/utils/valueSync';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { toFlatpickrFormat } from '$lib/utils/dateFormats';
 	import PrintRow from './common/PrintRow.svelte';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{ item: Item; printing?: boolean }>();
 	let value: string | null = $state(
 		(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? null) || null
 	);
 
-	let readOnly = $state(item.is_read_only ?? false);
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state
+	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
 	let hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
@@ -35,7 +48,7 @@
 	);
 
 	const rules = $derived.by(() =>
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'date' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'date' })
 	);
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
@@ -124,13 +137,15 @@
 		state[key] = v;
 	});
 
-	const a11y = buildFieldAria({
-		uuid: item.uuid,
-		labelText,
-		helperText,
-		isRequired: item.is_required,
-		readOnly
-	});
+	const a11y = $derived.by(() =>
+		buildFieldAria({
+			uuid: item.uuid,
+			labelText,
+			helperText,
+			isRequired,
+			readOnly: isReadOnly
+		})
+	);
 
 	// Filter out 'id' from attributes for the outer DatePicker wrapper to prevent
 	// duplicate IDs when inside a repeater (the wrapper div should not have an ID)
@@ -170,7 +185,7 @@
 				data-kiln-date="true"
 				data-kiln-uuid={item.uuid}
 			>
-				<span slot="labelChildren" class:required={item.is_required} class:moustache={enableVarSub}
+				<span slot="labelChildren" class:required={isRequired} class:moustache={enableVarSub}
 					>{@html labelText}</span
 				>
 			</DatePickerInput>

--- a/src/lib/components/formfields/NumberInput.svelte
+++ b/src/lib/components/formfields/NumberInput.svelte
@@ -9,11 +9,19 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import { preprocessDecimalInput, unmaskNumberString } from '$lib/utils/mask';
 	import PrintRow from './common/PrintRow.svelte';
 	import { MaskInput } from 'maska';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	let {
 		item,
@@ -28,7 +36,13 @@
 	);
 	let unmaskedValue: string = $derived(unmaskNumberString(value));
 	let error = $state(item.attributes?.error ?? ''); // this seems unused or broken
-	let readonly = $derived(item.is_read_only === true || item.is_read_only === 'true' || false);
+
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state
+	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $derived(getFieldLabel(item));
 	let helperText = item.help_text ?? '';
 	let hideLabel = item.attributes?.hideLabel ?? false;
@@ -55,7 +69,7 @@
 
 	let rules = $derived.by(() => {
 		const r = rulesFromAttributes(item.attributes, {
-			is_required: item.is_required,
+			is_required: isRequired,
 			type: 'number'
 		});
 		// If maskType indicates integer, enforce integer rule
@@ -119,8 +133,8 @@
 			uuid: item.uuid,
 			labelText,
 			helperText,
-			isRequired: item.is_required,
-			readOnly: readonly
+			isRequired,
+			readOnly: isReadOnly
 		})
 	);
 
@@ -169,7 +183,7 @@
 			<span
 				slot="labelChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 		</FieldComponent>

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -10,8 +10,16 @@
 	} from '$lib/utils/valueSync';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import PrintRow from './common/PrintRow.svelte';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -22,7 +30,13 @@
 		item?.value ?? item.attributes?.selected ?? item.attributes?.defaultSelected ?? ''
 	);
 	let error = $state(item.attributes?.error ?? '');
-	let readonly = $state(item.is_read_only ?? false);
+
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state
+	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
 	let hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
@@ -33,7 +47,7 @@
 	let extAttrs = $state<Record<string, any>>({});
 
 	const rules = $derived.by(() =>
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'string' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
@@ -81,13 +95,15 @@
 		publishToGlobalFormState({ item, value: selected });
 	});
 
-	const a11y = buildFieldAria({
-		uuid: item.uuid,
-		labelText,
-		helperText,
-		isRequired: item.is_required,
-		readOnly: readonly
-	});
+	const a11y = $derived.by(() =>
+		buildFieldAria({
+			uuid: item.uuid,
+			labelText,
+			helperText,
+			isRequired,
+			readOnly: isReadOnly
+		})
+	);
 </script>
 
 {#snippet value()}
@@ -123,7 +139,7 @@
 			<span
 				slot="legendChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 

--- a/src/lib/components/formfields/Select.svelte
+++ b/src/lib/components/formfields/Select.svelte
@@ -9,9 +9,17 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -22,7 +30,13 @@
 		item?.value ?? item.attributes?.selected ?? item.attributes?.defaultSelected ?? ''
 	);
 	let error = $state(item.attributes?.error ?? '');
-	let readOnly = $state(item.is_read_only ?? false);
+
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state (bindings, UI)
+	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
 	let helperText = item.help_text ?? '';
 	let hideLabel = item.attributes?.hideLabel ?? false;
@@ -38,7 +52,7 @@
 	});
 
 	const rules = $derived.by(() =>
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'string' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
@@ -91,8 +105,8 @@
 			uuid: item.uuid,
 			labelText,
 			helperText,
-			isRequired: item.is_required,
-			readOnly: readOnly
+			isRequired,
+			readOnly: isReadOnly
 		})
 	);
 </script>
@@ -118,7 +132,7 @@
 			<span
 				slot="labelChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 			<SelectItem value="" text="Please select an option" />
@@ -127,7 +141,12 @@
 			{/each}
 		</Select>
 		{#if anyError}
-			<div id={a11y.errorId} class="bx--form-requirement" class:moustache={enableVarSub} role="alert">
+			<div
+				id={a11y.errorId}
+				class="bx--form-requirement"
+				class:moustache={enableVarSub}
+				role="alert"
+			>
 				{anyError}
 			</div>
 		{/if}

--- a/src/lib/components/formfields/TextArea.svelte
+++ b/src/lib/components/formfields/TextArea.svelte
@@ -9,9 +9,17 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -20,7 +28,13 @@
 
 	let value = $state(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? '');
 	let error = $state(item.attributes?.error ?? '');
-	let readOnly = $state(item.is_read_only ?? false);
+
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state
+	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
 	let placeholder = item.attributes?.placeholder ?? '';
 	let helperText = item.help_text ?? '';
@@ -32,7 +46,7 @@
 	let extAttrs = $state<Record<string, any>>({});
 
 	const rules = $derived.by(() =>
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'string' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
@@ -87,8 +101,8 @@
 			uuid: item.uuid,
 			labelText,
 			helperText,
-			isRequired: item.is_required,
-			readOnly
+			isRequired,
+			readOnly: isReadOnly
 		})
 	);
 </script>
@@ -117,7 +131,7 @@
 			<span
 				slot="labelChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 		</TextArea>

--- a/src/lib/components/formfields/TextInput.svelte
+++ b/src/lib/components/formfields/TextInput.svelte
@@ -9,10 +9,18 @@
 		syncExternalAttributes
 	} from '$lib/utils/valueSync';
 	import './fields.css';
-	import { filterAttributes, buildFieldAria, getFieldLabel } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		buildFieldAria,
+		getFieldLabel,
+		computeIsRequired,
+		computeIsReadOnly
+	} from '$lib/utils/helpers';
 	import { normalizeDash, filterInputByMaskType, applyMaskaWithTokens } from '$lib/utils/mask';
 	import { validateValue, rulesFromAttributes, validateMaskedValue } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+
+	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
 	const { item, printing = false } = $props<{
 		item: Item;
@@ -21,7 +29,6 @@
 
 	let value = $state(item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? '');
 	let error = $state(item.attributes?.error ?? '');
-	let readOnly = $state(item.is_read_only ?? false);
 	let labelText = $state(getFieldLabel(item));
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
 	let placeholder = item.attributes?.placeholder ?? '';
@@ -39,9 +46,17 @@
 	let touched = $state(false);
 	let extAttrs = $state<Record<string, any>>({});
 
+	// Compute effective required/read-only from enum values
+	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
+	const isReadOnly = $derived.by(() => computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
+	// Use computed isReadOnly for local state (bindings, UI)
+	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+
 	const rules = $derived.by(() =>
-		rulesFromAttributes(item.attributes, { is_required: item.is_required, type: 'string' })
+		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;
@@ -49,7 +64,6 @@
 
 		const maskType = item?.attributes?.maskType;
 		const label = item.attributes?.labelText ?? item.name;
-		const isRequired = item.is_required === true;
 
 		// Delegate mask-aware checks (phone, email, postal code) to shared helper
 		const maskErr = validateMaskedValue(value, item.attributes, { fieldLabel: label, isRequired });
@@ -114,15 +128,16 @@
 		publishToGlobalFormState({ item, value });
 	});
 
-	const a11y = buildFieldAria({
-		uuid: item.uuid,
-		labelText,
-		helperText,
-		isRequired: item.is_required,
-		readOnly: readOnly
-	});
+	const a11y = $derived.by(() =>
+		buildFieldAria({
+			uuid: item.uuid,
+			labelText,
+			helperText,
+			isRequired,
+			readOnly: isReadOnly
+		})
+	);
 
-	// Apply mask to the real input element once it exists
 	let maskApplied = false;
 	$effect(() => {
 		if (maskApplied || typeof document === 'undefined') return;
@@ -166,7 +181,7 @@
 			<span
 				slot="labelChildren"
 				id={a11y.labelId}
-				class:required={item.is_required}
+				class:required={isRequired}
 				class:moustache={enableVarSub}>{@html labelText}</span
 			>
 		</TextInput>

--- a/src/lib/types/form.ts
+++ b/src/lib/types/form.ts
@@ -5,10 +5,10 @@ export interface Item {
 	name: string;
 	description?: string;
 	help_text?: string;
-	is_required?: boolean;
+	is_required?: 'always' | 'portal';
 	visible_web?: boolean;
 	visible_pdf?: boolean;
-	is_read_only?: boolean | string;
+	is_read_only?: 'always' | 'portal';
 	save_on_submit?: boolean;
 	order?: number;
 	options?: FormOption[] | any[];

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -21,6 +21,38 @@ export function getApiUrl(path: string, envVar?: string): string {
       return `/api${path}`;
 }
 
+/**
+ * Compute effective isRequired boolean from enum value.
+ * @param value - The is_required enum value ('always', 'portal', true, false, or null)
+ * @param isPortalIntegrated - Whether portal integration is enabled
+ */
+export function computeIsRequired(
+	value: boolean | 'always' | 'portal' | null | undefined,
+	isPortalIntegrated: boolean
+): boolean {
+	if (!value) return false;
+	if (value === 'always') return true;
+	if (value === 'portal') return isPortalIntegrated;
+	if (value === true) return true;
+	return false;
+}
+
+/**
+ * Compute effective isReadOnly boolean from enum value.
+ * @param value - The is_read_only enum value ('always', 'portal', true, false, or null)
+ * @param isPortalIntegrated - Whether portal integration is enabled
+ */
+export function computeIsReadOnly(
+	value: boolean | 'always' | 'portal' | string | null | undefined,
+	isPortalIntegrated: boolean
+): boolean {
+	if (!value) return false;
+	if (value === 'always') return true;
+	if (value === 'portal') return isPortalIntegrated;
+	if (value === true) return true;
+	return false;
+}
+
 /** Set is_read_only on all items under formData.elements. */
 export function setReadOnlyFields(formData: any) {
 		function recurse(items: any[]) {


### PR DESCRIPTION
## What changes did you make?

Added handlers on each element type to compute the required/read-only state based on the modified `is_required`/`is_read_only` enums from form JSON and the portal integration state from `.env`.

These changes are compatible with JSONs generated before the accompanying Klamm changes were applied.

## Why did you make these changes?

ADO 3613

## What alternatives did you consider?

None

### Checklist

- [x] **I have assigned at least one reviewer**
- [x] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
