### PR TITLE
ADO-3479 Limit repeater instances

### DIFF
--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -578,10 +578,11 @@
 						const root = document.querySelector<HTMLElement>(selectors(id));
 						if (!root) return;
 
-						const focusable =
-							(root.matches?.('input,select,textarea')
+						const focusable = root.matches?.('fieldset')
+							? root.querySelector('.custom-buttons-only button') || root
+							: root.matches?.('input,select,textarea')
 								? root
-								: root.querySelector('input,select,textarea')) || root;
+								: root.querySelector('input,select,textarea') || root;
 
 						try {
 							focusable.dispatchEvent(new Event('focus', { bubbles: true }));

--- a/src/lib/components/formfields/Button.svelte
+++ b/src/lib/components/formfields/Button.svelte
@@ -1,16 +1,24 @@
 <script lang="ts">
 	import { Button } from 'carbon-components-svelte';
 	import type { Item } from '$lib/types/form';
-	import { filterAttributes, getFieldLabel, computeIsReadOnly } from '$lib/utils/helpers';
+	import {
+		filterAttributes,
+		getFieldLabel,
+		computeIsReadOnly,
+		buildFieldAria
+	} from '$lib/utils/helpers';
 	import { syncExternalAttributes } from '$lib/utils/valueSync';
-	import { buildFieldAria } from '$lib/utils/helpers';
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
-	let { item, printing = false } = $props<{ item: Item; printing?: boolean; [key: string]: any }>();
-	let labelText = $derived(getFieldLabel(item));
-	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
-	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
+	const { item, printing = false } = $props<{
+		item: Item;
+		printing?: boolean;
+		[key: string]: any;
+	}>();
+	const labelText = $derived(getFieldLabel(item));
+	const enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
+	const readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 
 	let extAttrs = $state<Record<string, any>>({});
 	let ariaLabel = $derived(labelText || item.name || 'button');

--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -37,14 +37,14 @@
 
 	// Use computed isReadOnly for local state (bindings, UI)
 	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
-	let helperText = item.help_text ?? '';
-	let hideLabel = item.attributes?.hideLabel ?? false;
+	const helperText = item.help_text ?? '';
+	const hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
 	let touched = $state(false);
 
 	let extAttrs = $state<Record<string, any>>({});
 
-	let filteredAttributes = $derived.by(() => {
+	const filteredAttributes = $derived.by(() => {
 		const attrs = { ...(item.attributes ?? {}) } as Record<string, any>;
 		delete attrs.checked;
 		delete attrs.defaultChecked;
@@ -52,10 +52,11 @@
 		return attrs;
 	});
 
-	const rules = $derived.by(() =>
+	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'boolean' })
 	);
-	let anyError = $derived.by(() => {
+
+	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (item.attributes?.error) return item.attributes.error;
 		if (readonly) return '';

--- a/src/lib/components/formfields/Container.svelte
+++ b/src/lib/components/formfields/Container.svelte
@@ -32,19 +32,39 @@
 		});
 	}
 
-	// Initialize groups based on existing data or create one empty group
+	const minRepeats = $derived(item.attributes?.minRepeats ?? 1);
+	const maxRepeats = $derived(item.attributes?.maxRepeats ?? Infinity);
+
+	// Initialize groups based on existing data or create the minimum required empty groups
 	let groups = $state(initializeGroups());
 
 	function initializeGroups() {
-		// Check for save data
+		// Use saved data if present
 		if (item.repeaterData && Array.isArray(item.repeaterData) && item.repeaterData.length > 0) {
-			return item.repeaterData.map((data, index) => ({
+			const loaded = item.repeaterData.map((data, index) => ({
 				id: generateUUID(),
-				data: data,
-				index: index
+				data,
+				index
 			}));
+
+			// If saved data is fewer than minRepeats, auto-add extra blank groups
+			while (loaded.length < minRepeats) {
+				loaded.push({
+					id: generateUUID(),
+					data: {},
+					index: loaded.length
+				});
 		}
-		return [{ id: generateUUID(), data: {}, index: 0 }];
+
+			return loaded;
+		}
+
+		// Otherwise create minRepeats empty groups
+		return Array.from({ length: minRepeats }, (_, i) => ({
+			id: generateUUID(),
+			data: {},
+			index: i
+		}));
 	}
 
 	let isRepeatable = $derived(item.attributes?.isRepeatable === true);
@@ -131,6 +151,8 @@
 	}
 
 	function addGroup() {
+		if (groups.length >= maxRepeats) return; // prevent exceeding max
+
 		const newGroup = {
 			id: generateUUID(),
 			data: {},
@@ -138,14 +160,17 @@
 		};
 		groups.push(newGroup);
 		groups = groups;
+
 		// keep registry in sync
 		syncActiveGroupsRegistry();
 	}
 
 	function removeGroup(index: number) {
-		if (groups.length <= 1) return;
+		if (groups.length <= minRepeats) return; // prevent going below min
+
 		groups.splice(index, 1);
 		groups = groups.map((group, idx) => ({ ...group, index: idx }));
+
 		// update registry and purge any stale keys that belonged to the removed group
 		syncActiveGroupsRegistry();
 		cleanupStaleFormState();
@@ -282,7 +307,7 @@
 							>{repeaterItemLabel}
 							{repeaterItemLabel ? idx + 1 : ' '}</span
 						>
-						{#if groupCount > 1 && !isReadOnly}
+						{#if groupCount > minRepeats && !item.is_read_only}
 							<Button
 								kind="ghost"
 								onclick={() => removeGroup(idx)}
@@ -328,7 +353,13 @@
 		{/each}
 		{#if !printing && !isReadOnly && isRepeatable}
 			<div class="custom-buttons-only">
-				<Button kind="ghost" onclick={addGroup} icon={Add} class="no-print">Add another</Button>
+				<Button
+					kind="ghost"
+					onclick={addGroup}
+					icon={Add}
+					class="no-print"
+					disabled={groups.length >= maxRepeats}>Add another</Button
+				>
 			</div>
 		{/if}
 	</fieldset>

--- a/src/lib/components/formfields/Container.svelte
+++ b/src/lib/components/formfields/Container.svelte
@@ -6,7 +6,7 @@
 	import { computeIsReadOnly } from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 
-	let {
+	const {
 		item,
 		mode,
 		printing = false
@@ -55,7 +55,7 @@
 					data: {},
 					index: loaded.length
 				});
-		}
+			}
 
 			return loaded;
 		}
@@ -68,6 +68,13 @@
 		}));
 	}
 
+	const isRepeatable = $derived(item.attributes?.isRepeatable === true);
+	const legend = $derived(item.attributes?.legend ?? '');
+	const level = $derived(item.attributes?.level ?? 2);
+	const enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
+	const repeaterItemLabel = $derived(item.attributes?.repeaterItemLabel ?? null);
+	const children = $derived(item.children ?? []);
+	const groupCount = $derived(groups.length);
 
 	const rules = $derived({
 		...rulesFromAttributes(item.attributes, { type: 'container' })
@@ -275,11 +282,11 @@
 
 	type ContainerType = keyof typeof containerTypeClassMap;
 
-	let containerType: ContainerType = $derived(
+	const containerType: ContainerType = $derived(
 		(item.attributes?.containerType as ContainerType) ?? 'section'
 	);
-	let containerClass = $derived(containerTypeClassMap[containerType] ?? 'container-section');
-	let containerStyle = $derived(containerTypeStyleMap[containerType] ?? '');
+	const containerClass = $derived(containerTypeClassMap[containerType] ?? 'container-section');
+	const containerStyle = $derived(containerTypeStyleMap[containerType] ?? '');
 
 	const legendId = `${item.uuid}-legend`;
 	const errorId = `${item.uuid}-error`;

--- a/src/lib/components/formfields/Container.svelte
+++ b/src/lib/components/formfields/Container.svelte
@@ -4,6 +4,7 @@
 	import FieldRenderer from '../FieldRenderer.svelte';
 	import type { Item } from '$lib/types/form';
 	import { computeIsReadOnly } from '$lib/utils/helpers';
+	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 
 	let {
 		item,
@@ -67,13 +68,19 @@
 		}));
 	}
 
-	let isRepeatable = $derived(item.attributes?.isRepeatable === true);
-	let legend = $derived(item.attributes?.legend ?? '');
-	let level = $derived(item.attributes?.level ?? 2);
-	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
-	let repeaterItemLabel = $derived(item.attributes?.repeaterItemLabel ?? null);
-	let children = $derived(item.children ?? []);
-	let groupCount = $derived(groups.length);
+
+	const rules = $derived({
+		...rulesFromAttributes(item.attributes, { type: 'container' })
+	});
+
+	const anyError = $derived.by(() => {
+		return (
+			validateValue(groups.length, rules, {
+				type: 'container',
+				fieldLabel: item.attributes?.labelText ?? item.name
+			}).firstError ?? ''
+		);
+	});
 
 	function win(): any | undefined {
 		return typeof window === 'undefined' ? undefined : (window as any);
@@ -275,6 +282,7 @@
 	let containerStyle = $derived(containerTypeStyleMap[containerType] ?? '');
 
 	const legendId = `${item.uuid}-legend`;
+	const errorId = `${item.uuid}-error`;
 
 	const isVisible = $derived(
 		(!printing && item.visible_web !== false) || (printing && item.visible_pdf !== false)
@@ -360,6 +368,17 @@
 					class="no-print"
 					disabled={groups.length >= maxRepeats}>Add another</Button
 				>
+
+				{#if anyError}
+					<div
+						id={errorId}
+						class="bx--form-requirement"
+						class:moustache={enableVarSub}
+						role="alert"
+					>
+						{anyError}
+					</div>
+				{/if}
 			</div>
 		{/if}
 	</fieldset>
@@ -404,6 +423,9 @@
 		border: none;
 		padding: 0;
 		margin-bottom: 20px;
+	}
+	:global(.bx--btn--ghost:disabled) {
+		opacity: 0.5;
 	}
 
 	@media print {

--- a/src/lib/components/formfields/CurrencyInput.svelte
+++ b/src/lib/components/formfields/CurrencyInput.svelte
@@ -34,7 +34,7 @@
 	let value: string = $state(
 		item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? ''
 	);
-	let unmaskedValue: string = $derived(unmaskNumberString(value));
+	const unmaskedValue: string = $derived(unmaskNumberString(value));
 
 	// Compute effective required/read-only from enum values
 	const isRequired = $derived.by(() => computeIsRequired(item.is_required, isPortalIntegrated));
@@ -42,23 +42,24 @@
 
 	// Use computed isReadOnly for local state
 	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
-	let labelText = $derived(getFieldLabel(item));
-	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
-	let placeholder = $derived(item.attributes?.placeholder ?? '');
-	let helperText = $derived(item.help_text ?? item.description ?? '');
+	const labelText = $derived(getFieldLabel(item));
+	const enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
+	const placeholder = $derived(item.attributes?.placeholder ?? '');
+	const helperText = $derived(item.help_text ?? item.description ?? '');
 
-	let hideLabel = $derived(item.attributes?.hideLabel ?? false);
+	const hideLabel = $derived(item.attributes?.hideLabel ?? false);
 
 	let touched = $state(false);
 	let extAttrs = $state<Record<string, any>>({});
 
 	let ref = $state<HTMLInputElement | null>(null);
 
-	let rules = $derived.by(() => ({
+	const rules = $derived({
 		...rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'number' }),
 		isInteger: false
-	}));
-	let anyError = $derived.by(() => {
+	});
+
+	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (readOnly) return '';
 		return (

--- a/src/lib/components/formfields/DatePicker.svelte
+++ b/src/lib/components/formfields/DatePicker.svelte
@@ -28,8 +28,8 @@
 	// Use computed isReadOnly for local state
 	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
-	let hideLabel = item.attributes?.hideLabel ?? false;
-	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
+	const hideLabel = item.attributes?.hideLabel ?? false;
+	const enableVarSub = $state(item.attributes?.enableVarSub ?? false);
 	let helperText = item.help_text ?? '';
 	let touched = $state(false);
 
@@ -47,7 +47,7 @@
 		)
 	);
 
-	const rules = $derived.by(() =>
+	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'date' })
 	);
 	const anyError = $derived.by(() => {

--- a/src/lib/components/formfields/NumberInput.svelte
+++ b/src/lib/components/formfields/NumberInput.svelte
@@ -34,7 +34,7 @@
 	let value: string = $state(
 		item?.value ?? item.attributes?.value ?? item.attributes?.defaultValue ?? ''
 	);
-	let unmaskedValue: string = $derived(unmaskNumberString(value));
+	const unmaskedValue: string = $derived(unmaskNumberString(value));
 	let error = $state(item.attributes?.error ?? ''); // this seems unused or broken
 
 	// Compute effective required/read-only from enum values
@@ -43,11 +43,11 @@
 
 	// Use computed isReadOnly for local state
 	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
-	let labelText = $derived(getFieldLabel(item));
-	let helperText = item.help_text ?? '';
-	let hideLabel = item.attributes?.hideLabel ?? false;
-	let enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
-	let maskType = $derived(item.attributes?.maskType ?? 'integer');
+	const labelText = $derived(getFieldLabel(item));
+	const helperText = item.help_text ?? '';
+	const hideLabel = item.attributes?.hideLabel ?? false;
+	const enableVarSub = $derived(item.attributes?.enableVarSub ?? false);
+	const maskType = $derived(item.attributes?.maskType ?? 'integer');
 	let fractionDigits = $derived.by(() => {
 		return item.attributes?.step
 			? (item.attributes?.step.toString().split('.')[1]?.length ?? 0)
@@ -56,7 +56,7 @@
 
 	// carbon's NumberInput has UX issues with decimal values, even with allowDecimal
 	// keep using it for integer for form script compatability
-	let FieldComponent = $derived(maskType === 'decimal' ? TextInput : NumberInput);
+	const FieldComponent = $derived(maskType === 'decimal' ? TextInput : NumberInput);
 
 	let touched = $state(false);
 	let ref = $state<HTMLInputElement | null>(null);
@@ -67,7 +67,7 @@
 		return value?.toString() || '';
 	});
 
-	let rules = $derived.by(() => {
+	const rules = $derived.by(() => {
 		const r = rulesFromAttributes(item.attributes, {
 			is_required: isRequired,
 			type: 'number'
@@ -76,7 +76,8 @@
 		if (maskType === 'integer') r.isInteger = true;
 		return r;
 	});
-	let anyError = $derived.by(() => {
+
+	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error; // would force display an error that can never change
 		if (readonly) return '';

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -40,17 +40,18 @@
 	// Use computed isReadOnly for local state
 	let readonly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
-	let hideLabel = item.attributes?.hideLabel ?? false;
+	const hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
-	let helperText = item.help_text ?? '';
-	let options = item.options ?? [];
+	const helperText = item.help_text ?? '';
+	const options = item.options ?? [];
 	let touched = $state(false);
 
 	let extAttrs = $state<Record<string, any>>({});
 
-	const rules = $derived.by(() =>
+	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;

--- a/src/lib/components/formfields/Select.svelte
+++ b/src/lib/components/formfields/Select.svelte
@@ -38,10 +38,10 @@
 	// Use computed isReadOnly for local state (bindings, UI)
 	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
-	let helperText = item.help_text ?? '';
-	let hideLabel = item.attributes?.hideLabel ?? false;
+	const helperText = item.help_text ?? '';
+	const hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
-	let options = item.options ?? [];
+	const options = item.options ?? [];
 	let touched = $state(false);
 
 	let extAttrs = $state<Record<string, any>>({});
@@ -51,9 +51,10 @@
 		return option?.label || selected;
 	});
 
-	const rules = $derived.by(() =>
+	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;

--- a/src/lib/components/formfields/TextArea.svelte
+++ b/src/lib/components/formfields/TextArea.svelte
@@ -36,16 +36,16 @@
 	// Use computed isReadOnly for local state
 	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 	let labelText = $state(getFieldLabel(item));
-	let placeholder = item.attributes?.placeholder ?? '';
-	let helperText = item.help_text ?? '';
-	let hideLabel = item.attributes?.hideLabel ?? false;
+	const placeholder = item.attributes?.placeholder ?? '';
+	const helperText = item.help_text ?? '';
+	const hideLabel = item.attributes?.hideLabel ?? false;
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
-	let maxlength = item.attributes?.maxCount ?? undefined;
+	const maxlength = item.attributes?.maxCount ?? undefined;
 	let touched = $state(false);
 
 	let extAttrs = $state<Record<string, any>>({});
 
-	const rules = $derived.by(() =>
+	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 	const anyError = $derived.by(() => {

--- a/src/lib/components/formfields/TextInput.svelte
+++ b/src/lib/components/formfields/TextInput.svelte
@@ -31,8 +31,8 @@
 	let error = $state(item.attributes?.error ?? '');
 	let labelText = $state(getFieldLabel(item));
 	let enableVarSub = $state(item.attributes?.enableVarSub ?? false);
-	let placeholder = item.attributes?.placeholder ?? '';
-	let helperText = item.help_text ?? item.description ?? '';
+	const placeholder = item.attributes?.placeholder ?? '';
+	const helperText = item.help_text ?? item.description ?? '';
 
 	//maska patterns:
 	// 	{
@@ -41,8 +41,8 @@
 	//   '*': { pattern: /[a-zA-Z0-9]/ }, // letters & digits
 	// }
 
-	let hideLabel = item.attributes?.hideLabel ?? false;
-	let maxCount = item.attributes?.maxCount ?? undefined;
+	const hideLabel = item.attributes?.hideLabel ?? false;
+	const maxCount = item.attributes?.maxCount ?? undefined;
 	let touched = $state(false);
 	let extAttrs = $state<Record<string, any>>({});
 
@@ -53,7 +53,7 @@
 	// Use computed isReadOnly for local state (bindings, UI)
 	let readOnly = $state(computeIsReadOnly(item.is_read_only, isPortalIntegrated));
 
-	const rules = $derived.by(() =>
+	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 

--- a/src/lib/utils/databinder.ts
+++ b/src/lib/utils/databinder.ts
@@ -25,6 +25,7 @@ function normalizeDate(v: any): any {
 type FieldType =
 	| 'text-input'
 	| 'textarea-input'
+	| 'currency-input'
 	| 'number-input'
 	| 'checkbox-input'
 	| 'select-input'
@@ -81,6 +82,7 @@ function setInjectedValueByType(newItem: any, rawValue: any) {
 			};
 			break;
 		}
+		case 'currency-input':
 		case 'textarea-input':
 		case 'text-input': {
 			const strVal = rawValue == null ? '' : String(rawValue);

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -576,7 +576,8 @@ export function validateAllFields(
 
   function runValidation(item: Item, state: Record<string, FieldValue>, ctx?: { container?: Item; rowIndex?: number }) {
     const type = getType(item);
-    const rules = rulesFromAttributes(item.attributes, { is_required: item.is_required, type });
+    const isRequired = computeIsRequired(item.is_required, isPortalIntegrated);
+    const rules = rulesFromAttributes(item.attributes, { is_required: isRequired, type });
     const fieldLabel = labelOf(item);
 
     // Use state first; if missing, fall back to item-provided value (e.g., preloaded/bound)

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -1,8 +1,11 @@
 import { isFieldVisible,hydrateFormStateFromDOM,getDOMId } from './form';
 import type { FormDefinition, Item, FieldValue } from '../types/form';
 import { isClassSpecMask, isRegexMask } from '$lib/utils/mask';
+import { computeIsRequired } from '$lib/utils/helpers';
 
-export type ValueType = 'string' | 'number' | 'date' | 'boolean';
+const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
+
+export type ValueType = 'string' | 'number' | 'date' | 'boolean' | 'container';
 
 export type ValidationRules = {
   required?: boolean;
@@ -10,6 +13,7 @@ export type ValidationRules = {
   max?: number;
   minLength?: number;
   maxLength?: number;
+  maxRepeats?: number;
   length?: number;
   step?: number;
   pattern?: RegExp | string;
@@ -18,6 +22,7 @@ export type ValidationRules = {
   isInteger?: boolean;
   isEmail?: boolean;
   isUrl?: boolean;
+  isRepeatable?: boolean;
   custom?:
   | ((value: any) => string | null | undefined)
   | Array<(value: any) => string | null | undefined>;
@@ -213,6 +218,8 @@ function buildErrorMessage(key: string, params: Record<string, any>, label: stri
       return `${label} must be on or before ${params.before}.`;
     case 'ten_digit_phone':
       return `${label} must have 10 digits.`;
+    case 'maxRepeats':
+      return `${label} cannot have more than ${params.maxRepeats} repeater instances.`;
     default:
       return `${label} is invalid.`;
   }
@@ -226,6 +233,18 @@ export function validateValue(
   const type: ValueType = opts.type ?? 'string';
   const label = opts.fieldLabel ?? 'This field';
   const errors: string[] = [];
+
+  if (type === 'container') {
+    // If container is not a repeater, skip validation
+    if (!rules.isRepeatable) {
+      return { valid: true, errors: [], firstError: null };
+    }
+
+    const hasMax = typeof rules.maxRepeats === 'number';
+    if (hasMax && value > (rules.maxRepeats as number)) {
+      errors.push(buildErrorMessage('maxRepeats', { maxRepeats: rules.maxRepeats }, label));
+    }
+  }
 
   const isEmpty = (() => {
     if (type === 'boolean') return value === undefined || value === null || value === false;
@@ -399,6 +418,10 @@ export function rulesFromAttributes(
   // Convenience flags
   if (attrs.email === true) rules.isEmail = true;
   if (attrs.url === true) rules.isUrl = true;
+
+  // Container-specific
+  if (attrs.isRepeatable === true) rules.isRepeatable = true;
+  if (attrs.maxRepeats != null) rules.maxRepeats = Number(attrs.maxRepeats);
 
   return rules;
 }

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -1,4 +1,4 @@
-import { isFieldVisible,hydrateFormStateFromDOM,getDOMId } from './form';
+import { isFieldVisible, hydrateFormStateFromDOM, getDOMId } from './form';
 import type { FormDefinition, Item, FieldValue } from '../types/form';
 import { isClassSpecMask, isRegexMask } from '$lib/utils/mask';
 import { computeIsRequired } from '$lib/utils/helpers';
@@ -152,7 +152,7 @@ export function validateMaskedValue(
     let emailRx: RegExp;
     if (typeof mask === 'string') {
       try {
-        emailRx = new RegExp(mask);        
+        emailRx = new RegExp(mask);
       } catch {
         emailRx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       }
@@ -386,7 +386,7 @@ export function rulesFromAttributes(
       // Allowed-character spec => permissive regex (allows partial typing)
       const re = classSpecToRegex(raw);
       if (re) rules.pattern = re;
-    } else if (isRegexMask(raw)) {      
+    } else if (isRegexMask(raw)) {
       try {
         rules.pattern = new RegExp(raw);
       } catch {
@@ -438,7 +438,7 @@ export function validateAllFields(
   errorList: string[];
   consolidatedMessage: string;
 } {
-  const win: any = typeof window !== 'undefined' ? window : undefined;  
+  const win: any = typeof window !== 'undefined' ? window : undefined;
 
   const formDefinition: FormDefinition =
     (win?.__kilnFormDefinition as FormDefinition) ??
@@ -446,7 +446,7 @@ export function validateAllFields(
 
   hydrateFormStateFromDOM(formDefinition);
   const effectiveFormState: Record<string, FieldValue> =
-    formState ?? (win?.__kilnFormState as Record<string, FieldValue>) ?? {};  
+    formState ?? (win?.__kilnFormState as Record<string, FieldValue>) ?? {};
 
   const effectiveItems: Item[] =
     items ?? ((formDefinition?.elements as Item[]) || []);
@@ -456,14 +456,15 @@ export function validateAllFields(
 
   const getType = (item: Item): ValueType => {
     switch (item.type) {
+      case 'container':
+        return 'container';
+      case 'currency-input':
       case 'number-input':
         return 'number';
       case 'date-select-input':
         return 'date';
       case 'checkbox-input':
         return 'boolean';
-      case 'currency-input':
-        return 'number';
       case 'select-input':
       case 'radio-input':
       case 'text-input':
@@ -499,7 +500,7 @@ export function validateAllFields(
       if (!key.startsWith(prefix)) continue;
       const matchedChildUuid = [...childUuids].find((cu) => key.endsWith(`-${cu}`));
       if (!matchedChildUuid) continue;
-    
+
       const rest = key.slice(prefix.length); // "<groupId>-<childUuid>"
       const suffix = `-${matchedChildUuid}`;
       const groupId = rest.slice(0, rest.length - suffix.length);
@@ -519,19 +520,24 @@ export function validateAllFields(
   }
 
   function validateItem(item: Item, state: Record<string, FieldValue>, ctx?: { container?: Item; rowIndex?: number }) {
-    
-    if (item.type === 'container' && item.children && isFieldVisible(item, 'web', true, ctx) ) {
+
+    if (item.type === 'container' && item.children && isFieldVisible(item, 'web', true, ctx)) {
       const isRepeatable = item.attributes?.isRepeatable === true;
 
       if (isRepeatable) {
         // Prefer explicit groupState rows when provided
         const containerKey = (item as any)._containerInstanceKey ?? item.uuid;
-        
+
         let rows = inferRowsFromState(item, effectiveFormState);
+
+        runValidation(
+          item,
+          { [item.uuid]: rows.length },
+          { container: ctx?.container }
+        );
+
         // NEW: force validation when container is visible but empty
-        if (rows.length === 0) {
-          rows = [{}];
-        }
+        rows = rows.length === 0 ? [{}] : rows;
 
         rows.forEach((rowState, idx) => {
           for (const child of item.children || []) {
@@ -582,7 +588,7 @@ export function validateAllFields(
 
     // Use state first; if missing, fall back to item-provided value (e.g., preloaded/bound)
     let value = state[item.uuid];
-    if (value === undefined || value === null ) {
+    if (value === undefined || value === null) {
       const fallback = item.attributes?.value ?? (item as any).value;
       if (fallback !== undefined) value = fallback;
     }
@@ -633,6 +639,6 @@ export function validateAllFields(
   } catch (e) {
     console.log('validation broadcast error:', e);
   }
-  
+
   return { isValid, errors, errorList, consolidatedMessage };
 }


### PR DESCRIPTION
## What changes did you make?

- Added support for min and max instance limits in repeaters
- Added a validation error when loading previously saved forms where the number of repeater instances exceeds the newly reduced max
- Fixed `runValidation` not working with the new portal-based required state
- Cleaned up imports and fixed variables that should/can be constants

## Why did you make these changes?

- ADO-3749: Add support for min and max instance limits in repeaters + new validation error
- The `runValidation` fix was added because this was not updated when the change was made to handle required based on the portal state
- Code cleanup: Cleaning up imports and fixing variables that should/can be constants

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
