### PR TITLE
ADO-3702 CSS margin changes

### DIFF
--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -237,13 +237,29 @@
 		const LETTER_WIDTH_PX = LETTER_WIDTH_INCHES * INCH_TO_PX; // 816px
 		const LETTER_HEIGHT_PX = LETTER_HEIGHT_INCHES * INCH_TO_PX; // 1056px
 
-		const PAGE_MARGIN_TOP_MM = 5;
-		const PAGE_MARGIN_RIGHT_MM = 15;
-		const PAGE_MARGIN_BOTTOM_MM = 20;
-		const PAGE_MARGIN_LEFT_MM = 15;
+		function getPrintMarginPx(varName: string): number {
+			const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
 
-		const PAGE_MARGIN_TOP_PX = PAGE_MARGIN_TOP_MM * MM_TO_PX; // ~19px
-		const PAGE_MARGIN_BOTTOM_PX = PAGE_MARGIN_BOTTOM_MM * MM_TO_PX; // ~76px
+			if (!value) return 0;
+
+			// Supports mm, px
+			if (value.endsWith('mm')) {
+				return parseFloat(value) * MM_TO_PX;
+			}
+
+			if (value.endsWith('px')) {
+				return parseFloat(value);
+			}
+
+			return 0;
+		}
+
+		const PAGE_MARGIN_TOP_PX = getPrintMarginPx('--page-margin-top');
+		const PAGE_MARGIN_BOTTOM_PX = getPrintMarginPx('--page-margin-bottom');
+		const PAGE_MARGIN_LEFT_PX = getPrintMarginPx('--page-margin-left');
+		const PAGE_MARGIN_RIGHT_PX = getPrintMarginPx('--page-margin-right');
+
+		const PAGE_MARGIN_TOP_FIRST_PX = PAGE_MARGIN_TOP_PX;
 
 		// Detect footer height
 		const printFooter = document.querySelector('.print-footer') as HTMLElement;
@@ -302,8 +318,13 @@
 			LETTER_HEIGHT_PX - PAGE_MARGIN_TOP_PX - PAGE_MARGIN_BOTTOM_PX - fakeFooterHeight
 		);
 
-		// First page has less space due to header
-		const firstPageContentHeight = Math.ceil(baseContentHeight - headerHeight);
+		// First page:
+		// Replace normal top margin with first-page top margin,
+		// then subtract header
+		const firstPageContentHeight = Math.ceil(
+			baseContentHeight + (PAGE_MARGIN_TOP_PX - PAGE_MARGIN_TOP_FIRST_PX) - headerHeight
+		);
+
 		const subsequentPageContentHeight = baseContentHeight;
 
 		// No safety margin - maximize content per page
@@ -317,7 +338,7 @@
 		};
 
 		// Make content visible for measurement:
-		const contentWidth = LETTER_WIDTH_PX - (PAGE_MARGIN_LEFT_MM + PAGE_MARGIN_RIGHT_MM) * MM_TO_PX;
+		const contentWidth = LETTER_WIDTH_PX - PAGE_MARGIN_LEFT_PX - PAGE_MARGIN_RIGHT_PX;
 		letterContent.style.display = 'block';
 		letterContent.style.visibility = 'hidden';
 		letterContent.style.position = 'absolute';

--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -213,6 +213,10 @@
 		const pageBreak = document.createElement('div');
 		pageBreak.className = 'page-break';
 		el.parentNode?.insertBefore(pageBreak, el);
+		// Add page-start marker to first el after page break
+		// Used for non-first page top margin adjustment via top padding
+		// Only way this can be done since first page margin is smaller than other pages
+		el.classList.add('page-start');
 	}
 
 	function paginateContentForPrint(): () => void {
@@ -422,7 +426,13 @@
 		letterContent.style.width = originalStyles.width;
 
 		return () => {
+			// Remove inserted page break elements
 			document.querySelectorAll('.page-break').forEach((el) => el.remove());
+
+			// Remove page-start markers
+			document.querySelectorAll('.page-start').forEach((el) => {
+				el.classList.remove('page-start');
+			});
 		};
 	}
 

--- a/src/lib/print.css
+++ b/src/lib/print.css
@@ -1,10 +1,22 @@
 /* Print-only styles consolidated for the entire form experience */
+
+/* Default page margins */
+:root {
+  --page-margin-top: 12mm;
+  --page-margin-right: 15mm;
+  --page-margin-bottom: 20mm;
+  --page-margin-left: 15mm;
+
+  --page-margin-top-first: var(--page-margin-top);
+}
+
 @media print {
-
-
   @page {
     size: letter;
-    margin: 5mm 15mm 20mm 15mm;
+    margin: var(--page-margin-top-first)
+            var(--page-margin-right)
+            var(--page-margin-bottom)
+            var(--page-margin-left);
 
     /* Top Right Bottom Left */
     @top-left {
@@ -296,5 +308,4 @@
   #barcode-placeholder svg {
     display: block;
   }
-
 }

--- a/src/lib/print.css
+++ b/src/lib/print.css
@@ -298,6 +298,12 @@
     margin: 0 !important;
     padding: 0 !important;
   }
+  
+  .page-start {
+    padding-top: calc(
+      var(--page-margin-top) - var(--page-margin-top-first)
+      ) !important;
+  }
 
   #barcode-placeholder {
     display: block !important;

--- a/src/routes/pdf/+page.svelte
+++ b/src/routes/pdf/+page.svelte
@@ -1,45 +1,42 @@
 <script lang="ts">
-    import PrivateRoute from "$lib/PrivateRoute.svelte";
-    import { InlineLoading, InlineNotification } from "carbon-components-svelte";
+	import PrivateRoute from '$lib/PrivateRoute.svelte';
+	import { InlineLoading, InlineNotification } from 'carbon-components-svelte';
 
-    import { API } from "$lib/utils/api";
-    import { usePdfLoader } from "$lib/utils/usePdfLoader";
+	import { API } from '$lib/utils/api';
+	import { usePdfLoader } from '$lib/utils/usePdfLoader';
 
-    const loader = usePdfLoader({
-        apiEndpoint: API.loadPDFFromICMData,    // your PDF endpoint
-        transformParams: (params) => ({ ...params })
-    });
+	const loader = usePdfLoader({
+		apiEndpoint: API.loadPDFFromICMData, // your PDF endpoint
+		transformParams: (params) => ({ ...params })
+	});
 
-    let { isLoading, error, pdfBlob } = loader;
+	let { isLoading, error, pdfBlob } = loader;
 
-    let pdfUrl: string | null = null;
+	let pdfUrl: string | null = null;
 
-    // Whenever the blob becomes available, convert to a local URL
-    $: if ($pdfBlob) {
-        pdfUrl = URL.createObjectURL($pdfBlob);
-    }
+	// Whenever the blob becomes available, convert to a local URL
+	$: if ($pdfBlob) {
+		pdfUrl = URL.createObjectURL($pdfBlob);
+	}
 </script>
 
-<style>
-    .pdf-container {
-        width: 100%;
-        height: calc(100vh - 20px); 
-        border: none;
-    }
-</style>
-
 <PrivateRoute>
-    {#if $isLoading}
-        <InlineLoading description="Generating PDF..." status="active" />
-
-    {:else if $error}
-        <InlineNotification kind="error" title="Error" subtitle={$error} />
-
-    {:else if pdfUrl}
-        <!-- Inline PDF viewer -->
-        <iframe class="pdf-container" src={pdfUrl} title="pdfForm"></iframe>
-
-    {:else}
-        <InlineNotification kind="warning" title="No PDF" subtitle="No PDF was generated." />
-    {/if}
+	{#if $isLoading}
+		<InlineLoading description="Generating PDF..." status="active" />
+	{:else if $error}
+		<InlineNotification kind="error" title="Error" subtitle={$error} />
+	{:else if pdfUrl}
+		<!-- Inline PDF viewer -->
+		<iframe class="pdf-container" src={pdfUrl} title="pdfForm"></iframe>
+	{:else}
+		<InlineNotification kind="warning" title="No PDF" subtitle="No PDF was generated." />
+	{/if}
 </PrivateRoute>
+
+<style>
+	.pdf-container {
+		width: 100%;
+		height: calc(100vh - 20px);
+		border: none;
+	}
+</style>


### PR DESCRIPTION
## What changes did you make?

- Change the page margins to use CSS variables to allow styling added in Klamm to the form to override the defaults
- Update the print footer height calculations to support the dynamic margins
- Set the first page top margin as the default top margin, since it is smaller, and the top margin for the other pages can be adjusted by adding top padding to the first element on the new page

## Why did you make these changes?

- Use CSS variables for the page margins
    - Allows template scripts to be used to override/set specific margins per form
    - This is needed to get the dynamic margin values when calculating the print footer placement
- Update the print footer height calculations to support the dynamic margins
    - Same reasoning as above
- Set the first page top margin as the default top margin
    - Using the non-first page top margin as the default wouldn't work since it's bigger than the first page top margin and would hard cut off everything above the top margin after adjusting for the first page

## What alternatives did you consider?

The non‑first‑page top margin was considered when setting the default top margin. However, because page margins hard‑clip any content outside their bounds, first‑page header content was cut off when it extended beyond the non‑first‑page top margin—even after adjusting content placement to simulate the first‑page top margin.

The CSS print rule `@page:first` was considered for setting the first page’s top margin. However, this approach caused the fixed footer logic to calculate page content height assuming the first page's top margin for all pages, resulting in incorrect footer positioning on subsequent pages.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
