### PR TITLE
ADO-3836

### DIFF
--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -114,7 +114,7 @@
 		{#each options as opt (opt.id)}
 			<div class="radio-print-option">
 				<span class="radio-icon">
-					{#if selected.includes(opt.value)}
+					{#if selected === opt.value}
 						<RadioFilledIcon aria-label="Selected" />
 					{:else}
 						<RadioIcon aria-label="Not selected" />


### PR DESCRIPTION
## What changes did you make?

For Printing, changed in Radio component so that the exact text is compared

## Why did you make these changes?

https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3836
Radio selection displays incorrectly in print if multiple option values begin with the same digit or character

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
