### PR TITLE
Paginate forms and update group print css

### DIFF
--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -346,13 +346,16 @@
 			display: contentRoot.style.display,
 			visibility: contentRoot.style.visibility,
 			position: contentRoot.style.position,
-			width: contentRoot.style.width
+			width: contentRoot.style.width,
+			opacity: contentRoot.style.opacity,
+			pointerEvents: contentRoot.style.pointerEvents
 		};
 
 		// Make content visible for measurement:
 		const contentWidth = LETTER_WIDTH_PX - PAGE_MARGIN_LEFT_PX - PAGE_MARGIN_RIGHT_PX;
 		contentRoot.style.display = 'block';
-		contentRoot.style.visibility = 'hidden';
+		contentRoot.style.opacity = '0';
+		contentRoot.style.pointerEvents = 'none';
 		contentRoot.style.position = 'absolute';
 		contentRoot.style.width = `${contentWidth}px`;
 		contentRoot.offsetHeight; // Force reflow
@@ -391,7 +394,7 @@
 			const allMatches = Array.from(contentRoot.querySelectorAll(formBreakableSelector)).filter(
 				(el) => {
 					const label = ((el as Element).id || (el as Element).className || '').toLowerCase();
-					return !el.closest('.print-footer') && !label.includes('footer');
+					return isActuallyVisible(el) && !el.closest('.print-footer') && !label.includes('footer');
 				}
 			);
 			// Keep only outermost matches (no nested duplicates)
@@ -415,10 +418,32 @@
 			}
 			return current;
 		}
+		function isActuallyVisible(el: Element): boolean {
+			const htmlEl = el as HTMLElement;
+			const style = window.getComputedStyle(htmlEl);
+			const rect = htmlEl.getBoundingClientRect();
+
+			if (style.display === 'none') return false;
+			if (style.visibility === 'hidden') return false;
+			if (htmlEl.hidden) return false;
+
+			const hasBox = rect.width > 0 || rect.height > 0;
+			const hasVisibleChild = Array.from(el.children).some((child) => {
+				const childRect = child.getBoundingClientRect();
+				const childStyle = window.getComputedStyle(child as HTMLElement);
+				return (
+				childStyle.display !== 'none' &&
+				childStyle.visibility !== 'hidden' &&
+				(childRect.width > 0 || childRect.height > 0)
+				);
+			});
+
+			return hasBox || hasVisibleChild;
+		}
 
 		function getBreakableChildren(el: Element): Element[] {
 			const children = Array.from(el.children).filter(
-				(child): child is Element => child instanceof Element
+				(child): child is Element => child instanceof Element && isActuallyVisible(child)
 			);
 
 			const groupContainers = children.filter((child) =>
@@ -429,7 +454,7 @@
 			const grid = children.find((child) => child.matches('.container-fields-grid'));
 			if (grid) {
 				const gridChildren = Array.from(grid.children).filter(
-					(child): child is Element => child instanceof Element
+					(child): child is Element => child instanceof Element && isActuallyVisible(child)
 				);
 
 				const gridContainers = gridChildren.filter((child) =>
@@ -491,7 +516,7 @@
 
 		function getRepeaterChildren(el: Element): Element[] {
 			const children = Array.from(el.children).filter(
-				(child): child is Element => child instanceof Element
+				(child): child is Element => child instanceof Element && isActuallyVisible(child)
 			);
 
 			const fieldBlocks = children.filter((child) => child.matches('.group-item-child-field'));
@@ -555,6 +580,10 @@
 			const totalElementHeight = elHeight + marginTop + marginBottom;
 			// Skip empty/hidden elements
 			if (totalElementHeight <= 0) {
+				return;
+			}
+
+			if (!isLetter && !isActuallyVisible(el)) {
 				return;
 			}
 
@@ -686,6 +715,8 @@
 		contentRoot.style.visibility = originalStyles.visibility;
 		contentRoot.style.position = originalStyles.position;
 		contentRoot.style.width = originalStyles.width;
+		contentRoot.style.opacity = originalStyles.opacity;
+contentRoot.style.pointerEvents = originalStyles.pointerEvents;
 
 		return () => {
 			// Remove inserted page break elements

--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -223,7 +223,15 @@
 		const letterContent = document.querySelector(
 			'.letter-content, [id^="letter-content-"]'
 		) as HTMLElement;
-		if (!letterContent) {
+		
+		const formContent = document.querySelector(
+			'.content-wrapper .form'
+		) as HTMLElement;
+		
+		const isLetter = !!letterContent;
+		const contentRoot = (letterContent || formContent) as HTMLElement;
+
+		if (!contentRoot) {
 			return () => {};
 		}
 
@@ -335,19 +343,19 @@
 		const SAFETY_MARGIN_PX = 0;
 
 		const originalStyles = {
-			display: letterContent.style.display,
-			visibility: letterContent.style.visibility,
-			position: letterContent.style.position,
-			width: letterContent.style.width
+			display: contentRoot.style.display,
+			visibility: contentRoot.style.visibility,
+			position: contentRoot.style.position,
+			width: contentRoot.style.width
 		};
 
 		// Make content visible for measurement:
 		const contentWidth = LETTER_WIDTH_PX - PAGE_MARGIN_LEFT_PX - PAGE_MARGIN_RIGHT_PX;
-		letterContent.style.display = 'block';
-		letterContent.style.visibility = 'hidden';
-		letterContent.style.position = 'absolute';
-		letterContent.style.width = `${contentWidth}px`;
-		letterContent.offsetHeight; // Force reflow
+		contentRoot.style.display = 'block';
+		contentRoot.style.visibility = 'hidden';
+		contentRoot.style.position = 'absolute';
+		contentRoot.style.width = `${contentWidth}px`;
+		contentRoot.offsetHeight; // Force reflow
 
 		const breakableTags = [
 			'p',
@@ -368,12 +376,170 @@
 		];
 		const breakableSelector = breakableTags.join(', ');
 
-		const breakableElements = letterContent.querySelectorAll(breakableSelector);
+		const formBreakableSelector = [
+			'fieldset', '.container-group', '.container-repeatable',
+			'.group-item-child-container', '.group-item-container',
+			'.container-fields-grid > .group-item-child-container', 'table',
+			'.print-row.visible', '.field-container.text-info-field.visible'
+		].join(', ');
+
+		let breakableElements: Element[];
+
+		if (isLetter) {
+			breakableElements = Array.from(contentRoot.querySelectorAll(breakableSelector));
+		} else {
+			const allMatches = Array.from(contentRoot.querySelectorAll(formBreakableSelector)).filter(
+				(el) => {
+					const label = ((el as Element).id || (el as Element).className || '').toLowerCase();
+					return !el.closest('.print-footer') && !label.includes('footer');
+				}
+			);
+			// Keep only outermost matches (no nested duplicates)
+			breakableElements = allMatches.filter((el) => {
+				const parentMatch = el.parentElement?.closest(formBreakableSelector);
+				return !parentMatch || !contentRoot.contains(parentMatch);
+			});
+		}
+
+		// Helpers for finding children container/elements
+		function unwrapContainers(children: Element[]): Element[] {
+			let current = children;
+			while (
+				current.length === 1 &&
+				current[0] instanceof Element &&
+				current[0].matches('.group-item-child-container')
+			) {
+				const next = getBreakableChildren(current[0]);
+				if (next.length === 0) break;
+				current = next;
+			}
+			return current;
+		}
+
+		function getBreakableChildren(el: Element): Element[] {
+			const children = Array.from(el.children).filter(
+				(child): child is Element => child instanceof Element
+			);
+
+			const groupContainers = children.filter((child) =>
+				child.matches('.group-item-child-container, .group-item-container')
+			);
+			if (groupContainers.length > 0) return unwrapContainers(groupContainers);
+
+			const grid = children.find((child) => child.matches('.container-fields-grid'));
+			if (grid) {
+				const gridChildren = Array.from(grid.children).filter(
+					(child): child is Element => child instanceof Element
+				);
+
+				const gridContainers = gridChildren.filter((child) =>
+					child.matches('.group-item-child-container')
+				);
+				if (gridContainers.length > 0) return unwrapContainers(gridContainers);
+
+				const gridSections = gridChildren.filter((child) =>
+					child.matches('fieldset, .container-group, .container-repeatable, table')
+				);
+				if (gridSections.length > 0) return unwrapContainers(gridSections);
+
+				const gridRows = gridChildren.flatMap((child) => {
+					if (child.matches('.group-item-child-field')) {
+						return Array.from(
+							child.querySelectorAll(':scope .print-row.visible, :scope .field-container.text-info-field.visible')
+						).filter((n): n is Element => n instanceof Element);
+					}
+					return [];
+				});
+				if (gridRows.length > 0) return gridRows;
+			}
+
+			const sections = children.filter((child) =>
+				child.matches('fieldset, .container-group, .container-repeatable, table')
+			);
+			if (sections.length > 0) return unwrapContainers(sections);
+
+			return children.filter((child) =>
+				child.matches('.print-row.visible, .field-container.text-info-field.visible')
+			);
+		}
+
+		function getGroupChildren(el: Element): Element[] {
+			const ownedFields = Array.from(
+				el.querySelectorAll('.group-item-child-field')
+			).filter((child): child is Element => {
+				if (!(child instanceof Element)) return false;
+				const owner = child.parentElement?.closest(
+					'.group-item-container, .group-item-child-container'
+				);
+				return owner === el;
+			});
+			if (ownedFields.length > 0) return ownedFields;
+
+			const ownedRows = Array.from(
+				el.querySelectorAll('.print-row.visible, .field-container.text-info-field.visible')
+			).filter((child): child is Element => {
+				if (!(child instanceof Element)) return false;
+				const owner = child.parentElement?.closest(
+					'.group-item-container, .group-item-child-container'
+				);
+				return owner === el;
+			});
+			if (ownedRows.length > 0) return ownedRows;
+
+			return getBreakableChildren(el);
+		}
+
+		function getRepeaterChildren(el: Element): Element[] {
+			const children = Array.from(el.children).filter(
+				(child): child is Element => child instanceof Element
+			);
+
+			const fieldBlocks = children.filter((child) => child.matches('.group-item-child-field'));
+			if (fieldBlocks.length > 0) return fieldBlocks;
+
+			const grid = children.find((child) => child.matches('.container-fields-grid'));
+			if (grid) {
+				const gridChildren = Array.from(grid.children).filter(
+					(child): child is Element => child instanceof Element
+				);
+
+				const gridFields = gridChildren.filter((child) => child.matches('.group-item-child-field'));
+				if (gridFields.length > 0) return gridFields;
+
+				const gridContainers = gridChildren.filter((child) =>
+					child.matches('.group-item-child-container, .group-item-container')
+				);
+				if (gridContainers.length > 0) return gridContainers;
+			}
+
+			return getBreakableChildren(el);
+		}
+
+		// Overhead calculations
+		function getContainerOverhead(el: Element, children: Element[]): number {
+			if (children.length === 0) return 0;
+			const parentRect = el.getBoundingClientRect();
+			const firstRect = children[0].getBoundingClientRect();
+			const lastRect = children[children.length - 1].getBoundingClientRect();
+			const rawOverhead =
+				Math.max(0, Math.round(firstRect.top - parentRect.top)) +
+				Math.max(0, Math.round(parentRect.bottom - lastRect.bottom));
+			return Math.min(rawOverhead, 80);
+		}
+
+		function getGroupOverhead(el: Element, children: Element[]): number {
+			if (children.length === 0) return 0;
+			const parentHeight = Math.ceil(el.getBoundingClientRect().height);
+			const childHeightSum = children.reduce(
+				(sum, child) => sum + Math.ceil(child.getBoundingClientRect().height), 0
+			);
+			return Math.min(Math.max(0, parentHeight - childHeightSum), 40);
+		}
 
 		let accumulatedHeight = 0;
 		let maxHeightForPage = Math.ceil(firstPageContentHeight - SAFETY_MARGIN_PX);
 
-		breakableElements.forEach((el) => {
+		function paginateNode(el: Element): void {
 			// Skip elements inside the footer (they shouldn't trigger page breaks)
 			if (el.closest('.print-footer')) {
 				return;
@@ -392,12 +558,40 @@
 				return;
 			}
 
-			// Skip element with breakable child elements
-			if (el.childElementCount > 0) {
+			// Skip element with breakable child elements (letter mode only)
+			if (isLetter && el.childElementCount > 0) {
 				for (const child of el.children) {
 					if (breakableTags.includes(child.tagName.toLowerCase())) {
 						return;
 					}
+				}
+			}
+
+			const pageBuffer = isLetter ? 0 : 4;
+			let remainingSpace = maxHeightForPage - accumulatedHeight - pageBuffer;
+
+			// Repeater handling (form mode only)
+			if (!isLetter && el.matches('.container-repeatable')) {
+				const children = getRepeaterChildren(el);
+				if (children.length > 0) {
+					const allGrouped = children.every((child) =>
+						child.matches('.group-item-container, .group-item-child-container, fieldset, .container-group')
+					);
+					const overhead = !allGrouped ? getContainerOverhead(el, children) : 0;
+
+					if (!el.hasAttribute('data-pagination-overhead-applied')) {
+						if (accumulatedHeight > 0 && accumulatedHeight + overhead > maxHeightForPage - pageBuffer) {
+							insertPageBreak(el);
+							maxHeightForPage = Math.ceil(subsequentPageContentHeight - SAFETY_MARGIN_PX);
+							accumulatedHeight = 0;
+						}
+						accumulatedHeight += overhead;
+						remainingSpace = maxHeightForPage - accumulatedHeight - pageBuffer;
+						el.setAttribute('data-pagination-overhead-applied', 'true');
+					}
+
+					children.forEach((child) => paginateNode(child));
+					return;
 				}
 			}
 
@@ -406,6 +600,72 @@
 				// Only insert page break if we have content on current page
 				// (prevents empty first page)
 				if (accumulatedHeight > 0) {
+
+					// Grouped container handling (form mode only)
+					if (!isLetter && el.matches('.group-item-container, .group-item-child-container')) {
+						const children = getGroupChildren(el);
+						if (children.length > 0 && !(children.length === 1 && children[0] === el)) {
+							const isInsideRepeater = !!el.closest('.container-repeatable');
+							const hasRepeatableChild = children.some((c) => c.matches('.container-repeatable'));
+							const elHeight = Math.ceil(el.getBoundingClientRect().height);
+							const splitIsWorthIt = remainingSpace >= elHeight * 0.4;
+
+							if (!splitIsWorthIt && !hasRepeatableChild) {
+								insertPageBreak(el);
+								maxHeightForPage = Math.ceil(subsequentPageContentHeight - SAFETY_MARGIN_PX);
+								accumulatedHeight = 0;
+							}
+
+							const overhead = getGroupOverhead(el, children);
+							if (!isInsideRepeater && overhead > 0 && !el.hasAttribute('data-grouped-overhead-applied')) {
+								const firstChildH = Math.ceil(children[0].getBoundingClientRect().height);
+								const spaceAfterOverhead = maxHeightForPage - (accumulatedHeight + overhead) - pageBuffer;
+								const overheadOrphansContent = firstChildH > 0
+									&& spaceAfterOverhead < firstChildH
+									&& firstChildH <= (maxHeightForPage - pageBuffer);
+
+								if (accumulatedHeight + overhead > maxHeightForPage - pageBuffer || overheadOrphansContent) {
+									insertPageBreak(el);
+									maxHeightForPage = Math.ceil(subsequentPageContentHeight - SAFETY_MARGIN_PX);
+									accumulatedHeight = 0;
+								}
+								accumulatedHeight += overhead;
+								el.setAttribute('data-grouped-overhead-applied', 'true');
+							}
+
+							children.forEach((child) => paginateNode(child));
+							return;
+						}
+					}
+
+					// Group item field handling (form mode only)
+					if (!isLetter && el.matches('.group-item-child-field')) {
+						insertPageBreak(el);
+						maxHeightForPage = Math.ceil(subsequentPageContentHeight - SAFETY_MARGIN_PX);
+						accumulatedHeight = Math.min(totalElementHeight, maxHeightForPage - pageBuffer);
+						return;
+					}
+
+					// try splitting via children (form mode only)
+					if (!isLetter) {
+						const children = getBreakableChildren(el);
+						if (children.length > 0) {
+							const firstChildHeight = Math.ceil(children[0].getBoundingClientRect().height);
+							const isInsideRepeater = !!el.closest('.container-repeatable');
+							const firstChildTallerThanPage = firstChildHeight > (maxHeightForPage - pageBuffer);
+							const splitIsWorthIt = firstChildTallerThanPage || (remainingSpace >= firstChildHeight * 0.3);
+
+							if (!isInsideRepeater && firstChildHeight > remainingSpace && !splitIsWorthIt) {
+								insertPageBreak(el);
+								maxHeightForPage = Math.ceil(subsequentPageContentHeight - SAFETY_MARGIN_PX);
+								accumulatedHeight = 0;
+								remainingSpace = maxHeightForPage - pageBuffer;
+							}
+							children.forEach((child) => paginateNode(child));
+							return;
+						}
+					}
+
 					insertPageBreak(el);
 					// Subsequent pages have more space (no header)
 					maxHeightForPage = Math.ceil(subsequentPageContentHeight - SAFETY_MARGIN_PX);
@@ -417,13 +677,15 @@
 			} else {
 				accumulatedHeight += totalElementHeight;
 			}
-		});
+		}
+
+		breakableElements.forEach((el) => paginateNode(el));
 
 		// Return original styles:
-		letterContent.style.display = originalStyles.display;
-		letterContent.style.visibility = originalStyles.visibility;
-		letterContent.style.position = originalStyles.position;
-		letterContent.style.width = originalStyles.width;
+		contentRoot.style.display = originalStyles.display;
+		contentRoot.style.visibility = originalStyles.visibility;
+		contentRoot.style.position = originalStyles.position;
+		contentRoot.style.width = originalStyles.width;
 
 		return () => {
 			// Remove inserted page break elements
@@ -432,6 +694,16 @@
 			// Remove page-start markers
 			document.querySelectorAll('.page-start').forEach((el) => {
 				el.classList.remove('page-start');
+			});
+
+			// Remove group wrapper overhead
+			document.querySelectorAll('[data-grouped-overhead-applied]').forEach((el) => {
+				el.removeAttribute('data-grouped-overhead-applied');
+			});
+
+			// Remove repeater wrapper overhead
+			document.querySelectorAll('[data-pagination-overhead-applied]').forEach((el) => {
+				el.removeAttribute('data-pagination-overhead-applied');
 			});
 		};
 	}

--- a/src/lib/print.css
+++ b/src/lib/print.css
@@ -54,6 +54,21 @@
     display: block !important;
     page-break-inside: avoid;
   }
+  .group-item-container {
+    border: 0 !important;
+    padding: 0 !important;
+    min-height: 0 !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    break-inside: auto !important;
+    page-break-inside: auto !important;
+  }
+
+  .group-item-child-container,
+  .group-item-child-field {
+    break-inside: avoid-page;
+    page-break-inside: avoid;
+  }
 
   /* Overall print page container */
   /* height 792 ( 11in @ 72dpi (approx), adjust per template ) */


### PR DESCRIPTION
## What changes did you make?

- Introduced logic to paginate form content (not just letters) based on available page height
- Added handling for:
  - Nested containers (sections, fields)
  - Repeaters and group items (including breaking at child level when needed)
- Improved styling of nested containers

## Why did you make these changes?

Pagination only worked with letters and not forms. These changes would paginate the form content better and prevent the form elements from clipping.

## What alternatives did you consider?

None.

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
