### PR TITLE
Ado 3810

### DIFF
--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -24,6 +24,11 @@
 	import { bindDataToForm } from './utils/databinder';
 	import { formatWithAppTokens } from '$lib/utils/dateFormats';
 	import OriginStyleOverride from './components/OriginStyleOverride.svelte';
+	import {
+		setScriptError,
+		clearScriptError,
+		clearAllScriptErrors
+		} from "$lib/utils/scriptErrorApi";
 
 	let {
 		saveData = undefined,
@@ -49,6 +54,10 @@
 
 	let barcode = $derived<{ content: string } | undefined>(formData?.barcode);
 	let securityClassification = $derived<string | undefined>(formData?.security_classification);
+
+	(window as any).setScriptError = setScriptError;
+	(window as any).clearScriptError = clearScriptError;
+	(window as any).clearAllScriptErrors = clearAllScriptErrors;
 
 	function resetModalRuntime() {
 		modalMode = 'info';

--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -20,6 +20,7 @@
 	import PrintRow from './common/PrintRow.svelte';
 	import CheckboxIcon from 'carbon-icons-svelte/lib/Checkbox.svelte';
 	import CheckboxFilledIcon from 'carbon-icons-svelte/lib/CheckboxCheckedFilled.svelte';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -56,10 +57,14 @@
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'boolean' })
 	);
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (item.attributes?.error) return item.attributes.error;
 		if (readonly) return '';
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(checked, rules, {
 				type: 'boolean',

--- a/src/lib/components/formfields/CheckboxGroup.svelte
+++ b/src/lib/components/formfields/CheckboxGroup.svelte
@@ -14,6 +14,8 @@
 	import './fields.css';
 	import CheckboxIcon from "carbon-icons-svelte/lib/Checkbox.svelte";
 	import CheckboxFilledIcon from "carbon-icons-svelte/lib/CheckboxCheckedFilled.svelte";
+	import { scriptErrors } from "$lib/utils/scriptErrors";
+
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -58,8 +60,12 @@
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched || readOnly) return error || '';
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(selected, rules, {
 				type: 'string',

--- a/src/lib/components/formfields/CurrencyInput.svelte
+++ b/src/lib/components/formfields/CurrencyInput.svelte
@@ -20,6 +20,7 @@
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
 	import { MaskInput } from 'maska';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -59,9 +60,13 @@
 		isInteger: false
 	});
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (readOnly) return '';
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(unmaskedValue, rules, {
 				type: 'number',

--- a/src/lib/components/formfields/DatePicker.svelte
+++ b/src/lib/components/formfields/DatePicker.svelte
@@ -13,6 +13,7 @@
 	} from '$lib/utils/helpers';
 	import { toFlatpickrFormat } from '$lib/utils/dateFormats';
 	import PrintRow from './common/PrintRow.svelte';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -63,10 +64,14 @@
 	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'date' })
 	);
+
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (formatError) return formatError;
 		if (item.attributes?.error) return item.attributes.error;
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		if (readOnly) return '';
 		return (
 			validateValue(value ?? '', rules, {

--- a/src/lib/components/formfields/NumberInput.svelte
+++ b/src/lib/components/formfields/NumberInput.svelte
@@ -20,6 +20,7 @@
 	import { preprocessDecimalInput, unmaskNumberString } from '$lib/utils/mask';
 	import PrintRow from './common/PrintRow.svelte';
 	import { MaskInput } from 'maska';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -77,10 +78,14 @@
 		return r;
 	});
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
-		if (error) return error; // would force display an error that can never change
+		//if (error) return error; // would force display an error that can never change
 		if (readonly) return '';
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(unmaskedValue, rules, {
 				type: 'number',

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -20,6 +20,7 @@
 	import PrintRow from './common/PrintRow.svelte';
 	import RadioIcon from 'carbon-icons-svelte/lib/RadioButton.svelte';
 	import RadioFilledIcon from 'carbon-icons-svelte/lib/RadioButtonChecked.svelte';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -52,10 +53,14 @@
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;
 		if (readonly) return '';
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(selected, rules, {
 				type: 'string',

--- a/src/lib/components/formfields/Select.svelte
+++ b/src/lib/components/formfields/Select.svelte
@@ -18,6 +18,7 @@
 	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -55,10 +56,14 @@
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;
 		if (readOnly) return '';
+		 // script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(selected, rules, {
 				type: 'string',

--- a/src/lib/components/formfields/TextArea.svelte
+++ b/src/lib/components/formfields/TextArea.svelte
@@ -18,6 +18,7 @@
 	} from '$lib/utils/helpers';
 	import { validateValue, rulesFromAttributes } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -48,10 +49,15 @@
 	const rules = $derived(
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
+
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;
 		if (readOnly) return '';
+		// script-driven error from global store
+ 		if (scriptError) return scriptError;
 		return (
 			validateValue(value, rules, {
 				type: 'string',

--- a/src/lib/components/formfields/TextInput.svelte
+++ b/src/lib/components/formfields/TextInput.svelte
@@ -19,6 +19,7 @@
 	import { normalizeDash, filterInputByMaskType, applyMaskaWithTokens } from '$lib/utils/mask';
 	import { validateValue, rulesFromAttributes, validateMaskedValue } from '$lib/utils/validation';
 	import PrintRow from './common/PrintRow.svelte';
+	import { scriptErrors } from "$lib/utils/scriptErrors";
 
 	const isPortalIntegrated = import.meta.env.VITE_IS_PORTAL_INTEGRATED === 'true';
 
@@ -57,6 +58,8 @@
 		rulesFromAttributes(item.attributes, { is_required: isRequired, type: 'string' })
 	);
 
+	const scriptError = $derived.by(() => $scriptErrors?.[item.uuid] ?? "");
+
 	const anyError = $derived.by(() => {
 		if (!touched) return '';
 		if (error) return error;
@@ -73,6 +76,8 @@
 			return '';
 		}
 
+		// script-driven error from global store
+ 		if (scriptError) return scriptError;
 		// For custom or other masks: use standard string validation
 		return (
 			validateValue(value, rules, {

--- a/src/lib/utils/scriptErrorApi.ts
+++ b/src/lib/utils/scriptErrorApi.ts
@@ -1,16 +1,24 @@
 import { scriptErrors } from "$lib/utils/scriptErrors";
 
+function syncToWindow(next: Record<string, string>) {
+  if (typeof window !== "undefined") {
+    (window as any).__kilnScriptErrors = next;
+  }
+}
+
 export function setScriptError(fieldId: string, message: string) {
-  scriptErrors.update((curr) => ({
-    ...curr,
-    [fieldId]: message
-  }));
+  scriptErrors.update((curr) => {
+    const next = { ...curr, [fieldId]: message };
+    syncToWindow(next);
+    return next;
+  });
 }
 
 export function clearScriptError(fieldId: string) {
   scriptErrors.update((curr) => {
     const next = { ...curr };
     delete next[fieldId];
+    syncToWindow(next);
     return next;
   });
 }

--- a/src/lib/utils/scriptErrorApi.ts
+++ b/src/lib/utils/scriptErrorApi.ts
@@ -1,0 +1,20 @@
+import { scriptErrors } from "$lib/utils/scriptErrors";
+
+export function setScriptError(fieldId: string, message: string) {
+  scriptErrors.update((curr) => ({
+    ...curr,
+    [fieldId]: message
+  }));
+}
+
+export function clearScriptError(fieldId: string) {
+  scriptErrors.update((curr) => {
+    const next = { ...curr };
+    delete next[fieldId];
+    return next;
+  });
+}
+
+export function clearAllScriptErrors() {
+  scriptErrors.set({});
+}

--- a/src/lib/utils/scriptErrors.ts
+++ b/src/lib/utils/scriptErrors.ts
@@ -1,0 +1,5 @@
+import { writable } from "svelte/store";
+
+export type ScriptErrors = Record<string, string>;
+
+export const scriptErrors = writable<ScriptErrors>({});

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -458,6 +458,9 @@ export function validateAllFields(
   const effectiveGroupState: Record<string, FieldValue[]> =
     groupState ?? (win?.__kilnGroupState as Record<string, FieldValue[]>) ?? {};
 
+  const scriptErrMap: Record<string, string> =
+  (win?.__kilnScriptErrors as Record<string, string>) ?? {};  
+
   const getType = (item: Item): ValueType => {
     switch (item.type) {
       case 'container':
@@ -606,14 +609,19 @@ export function validateAllFields(
     }
 
     const { firstError } = validateValue(value, rules, { type, fieldLabel });
-    if (firstError) {
+
+    const errorKey = getDOMId(item, ctx);
+    // NEW: merge script validation errors
+    const scriptError = scriptErrMap[errorKey];
+    const finalError = scriptError || firstError;
+    if (finalError) {
       isValid = false;
 
       // Create a unique key (handles repeatable rows without clobbering)
-      const errorKey = getDOMId(item, ctx);
+     
       // Surface only the first message per key (keep concise)
       if (!errors[errorKey]) {
-        errors[errorKey] = firstError;
+        errors[errorKey] = finalError;
 
         const pathParts: string[] = [];
         if (ctx?.container) {
@@ -625,7 +633,7 @@ export function validateAllFields(
           }
         }
         const pathPrefix = pathParts.length ? `${pathParts.join(' > ')}: ` : '';
-        errorList.push(`${pathPrefix}${fieldLabel} - ${firstError}`);
+        errorList.push(`${pathPrefix}${fieldLabel} - ${finalError}`);
       }
     }
   }


### PR DESCRIPTION
## What changes did you make?

Added a scriptError global store so that the errors can be set in script after performing validation on elements' id.
Each input component is updated so that script error is also included for field level errors
 
A sample form that has all the components and their sample script in KLAMM - https://klamm.social.gov.bc.ca/forms/forms/2138

Tested on all Production forms - Caregiver (9) and ICM (2) to make sure they don't break with the code change

## Why did you make these changes?

In our forms , there is capability of validation on individual fields like maxLength, min length, regex etc . This new feature enables the case where any fields can be validated based on another field and set errors on them. We can also add any additional feature on a particular field as well that is not already covered in the existing fields attributes.

https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3810/

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
