### PR TITLE
Preserve the original form definition for rendering/saving

### DIFF
--- a/src/lib/RenderFrame.svelte
+++ b/src/lib/RenderFrame.svelte
@@ -168,17 +168,24 @@
 			modalOpen = true;
 		});
 	}
+	
+	let originalFormDefinition = $derived.by(() => {
+		if (!formData) return null;
+		return formData?.formversion ? formData.formversion : formData;
+	});
 
 	let mergedFormData = $derived.by(() => {
 		if (!formData) return null;
 
+		const formDefinitionForRender = JSON.parse(JSON.stringify(originalFormDefinition));
+
 		if (mode === 'view' || mode === 'portalView') {
-			setReadOnlyFields(formData);
+			setReadOnlyFields(formDefinitionForRender);
 		}
 
 		return bindDataToForm({
-			data: saveData,
-			form_definition: formData?.formversion ? formData.formversion : formData
+			data:  saveData?.data ?? saveData,
+			form_definition: formDefinitionForRender
 		}).mappedFormDef;
 	});
 
@@ -720,8 +727,8 @@
 
 	// Expose current form definition and init form state for createSavedData
 	$effect(() => {
-		if (typeof window !== 'undefined' && mergedFormData) {
-			(window as any).__kilnFormDefinition = mergedFormData;
+		if (typeof window !== 'undefined' && originalFormDefinition) {
+			(window as any).__kilnFormDefinition = originalFormDefinition;
 			(window as any).__kilnFormState = (window as any).__kilnFormState || {};
 		}
 	});


### PR DESCRIPTION
## What changes did you make?

Refactored the renderer to preserve the original form definition during data binding.

## Why did you make these changes?

Form definition was being merged with the data bindings. This is not expected behaviour.

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
