### PR TITLE
Changes for  ADO-3883- Consistent Styles for Read only fields

### DIFF
--- a/src/lib/components/formfields/Checkbox.svelte
+++ b/src/lib/components/formfields/Checkbox.svelte
@@ -181,14 +181,7 @@
 </div>
 
 <style>
-	/* Scope to only checkboxes inside a read-only web-input container */
-	:global(.web-input.read-only .bx--checkbox-wrapper),
-	:global(.web-input.read-only .bx--checkbox-label),
-	:global(.web-input.read-only .bx--checkbox-label-text) {
-		color: black !important;
-		cursor: default !important;
-		opacity: 1 !important;
-	}
+	
 
 	/* If Carbon dims the checkbox box itself */
 	:global(.web-input.read-only .bx--checkbox) {

--- a/src/lib/components/formfields/DatePicker.svelte
+++ b/src/lib/components/formfields/DatePicker.svelte
@@ -214,7 +214,9 @@
 <div class="field-container date-picker-field">
 	<PrintRow {item} {printing} {labelText} value={value ?? ''} />
 
-	<div class="web-input" class:visible={!printing && item.visible_web !== false}>
+	<div class="web-input" 
+	class:readonly={readOnly} 
+	class:visible={!printing && item.visible_web !== false} >
 		<DatePicker
 			{...datePickerWrapperAttrs}
 			{...extAttrs as any}
@@ -262,20 +264,5 @@
 </div>
 
 <style>
-	:global(
-			input:disabled,
-			textarea:disabled,
-			select:disabled,
-			button:disabled,
-			checkbox:disabled,
-			textinput:disabled
-		) {
-		background-color: white !important;
-		color: black !important;
-		cursor: text !important;
-	}
-	:global(input:disabled::placeholder, textarea:disabled::placeholder) {
-		color: black !important;
-		opacity: 1 !important;
-	}
+	
 </style>

--- a/src/lib/components/formfields/RadioButton.svelte
+++ b/src/lib/components/formfields/RadioButton.svelte
@@ -136,7 +136,7 @@
 
 	<div
 		class="web-input radio-group-wrapper"
-		style={readonly ? 'pointer-events: none;' : ''}
+		class:readonly={readonly}
 		class:visible={!printing && item.visible_web !== false}
 		data-selected={selected}
 	>
@@ -148,6 +148,7 @@
 			bind:selected
 			hideLegend={hideLabel}
 			role="radiogroup"
+			disabled={readonly}
 			{...a11y.ariaProps}
 			{onchange}
 			{...extAttrs as any}

--- a/src/lib/components/formfields/Select.svelte
+++ b/src/lib/components/formfields/Select.svelte
@@ -165,21 +165,5 @@
 </div>
 
 <style>
-	:global(
-			input:disabled,
-			textarea:disabled,
-			select:disabled,
-			button:disabled,
-			checkbox:disabled,
-			textinput:disabled
-		) {
-		background-color: white !important;
-		color: black !important;
-		cursor: text !important;
-	}
-
-	:global(input:disabled::placeholder, textarea:disabled::placeholder) {
-		color: black !important;
-		opacity: 1 !important;
-	}
+	
 </style>

--- a/src/lib/web.css
+++ b/src/lib/web.css
@@ -162,3 +162,54 @@
   display: inline-flex;
   align-items: center;
 }
+
+/* The following contains the css for the read-only  */
+.bx--text-input__readonly-icon {
+	display: none;
+}
+
+.bx--text-input-wrapper--readonly .bx--text-input {
+    background: #EDEBE9 !important;
+    border: 1px solid #8D8D8D !important;
+}
+.bx--date-picker .bx--date-picker__input:disabled {
+  background:#EDEBE9 !important;
+  cursor: text !important;
+  color: black !important;
+}
+
+.web-input.readonly .bx--date-picker__icon {
+  color: #c6c6c6 !important;
+  fill: #c6c6c6 !important;
+  cursor: not-allowed !important;
+} 
+.bx--text-area:read-only {
+  background:#EDEBE9 !important;
+}
+.bx--select-input:disabled {
+  background:#EDEBE9 !important;
+  color: black !important;
+	cursor: text !important;
+}
+
+.bx--checkbox-group .bx--checkbox-label-text {
+  font-weight: 400;
+  color: #161616 !important;
+  cursor: text !important;
+}
+
+.bx--radio-button:disabled+.bx--radio-button__label {
+    color:  #161616 !important;
+   
+}
+.radio-group-wrapper.readonly .bx--radio-button__appearance {
+  cursor: not-allowed !important;
+}
+
+
+.bx--checkbox-label-text,
+.bx--label--disabled, .bx--form__helper-text--disabled,
+fieldset[disabled] .bx--label, fieldset[disabled] .bx--form__helper-text {
+  color: #525252 !important;
+}
+/* css for the read-only ends here */


### PR DESCRIPTION
## What changes did you make?

Made css improvements so the fields have consistent look and feel when in Read-only/disabled mode
Tested with existing PROD forms

## Why did you make these changes?

Some of the fields had labels grayed out when they were in ReadOnly mode , while some others looked normal until mouse was hovered over to see that they are in RO mode.
https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3883/

## What alternatives did you consider?

_Describe any alternative solutions you considered and why._

### Checklist

- [ ] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
